### PR TITLE
Hotfix/smpx sppedup

### DIFF
--- a/scripts/SimplexUI/mayaInterface.py
+++ b/scripts/SimplexUI/mayaInterface.py
@@ -1,3 +1,22 @@
+'''
+Copyright 2016, Blur Studio
+
+This file is part of Simplex.
+
+Simplex is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Simplex is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
+'''
+
 #pylint: disable=invalid-name
 import re, json, sys
 from contextlib import contextmanager
@@ -6,11 +25,11 @@ import maya.cmds as cmds
 import maya.OpenMaya as om
 from loadUiType import QtCore, Signal, QApplication, QSplashScreen, QDialog, QMainWindow
 
-sys.path.insert(0, r'C:\Program Files\Autodesk\Maya2016\Python\lib\site-packages')
+#sys.path.insert(0, r'C:\Program Files\Autodesk\Maya2016\Python\lib\site-packages')
 import alembic
 from alembic.Abc import V3fTPTraits, Int32TPTraits
 from alembic.AbcGeom import OPolyMeshSchemaSample
-sys.path.pop(0) # make sure to undo my stupid little hack
+#sys.path.pop(0) # make sure to undo my stupid little hack
 
 
 # UNDO STACK INTEGRATION


### PR DESCRIPTION
Greatly speed up the .smpx file loading in Maya by using the fast built-in nodes instead of reading the alembic data directly.