### PR TITLE
When extracting shapes, make sure to respect the filters on the tree.

### DIFF
--- a/scripts/SimplexUI/loadUiType.py
+++ b/scripts/SimplexUI/loadUiType.py
@@ -23,7 +23,7 @@ from cStringIO import StringIO
 
 try:
 	from PySide2 import QtGui, QtCore
-	from PySide2.QtCore import Signal, QSortFilterProxyModel, Slot
+	from PySide2.QtCore import Signal, QSortFilterProxyModel, Slot, QModelIndex
 	from PySide2.QtCore import Qt, QObject, QTimer, QPoint, QEvent, QItemSelection, QSettings
 	from PySide2.QtWidgets import QMessageBox, QInputDialog, QFileDialog, QMenu, QApplication
 	from PySide2.QtWidgets import QDialog, QMainWindow, QSplashScreen, QShortcut, QProgressDialog
@@ -35,7 +35,7 @@ except ImportError:
 	try:
 		from PySide import QtGui, QtCore
 		from PySide.QtCore import Signal, Slot
-		from PySide.QtCore import Qt, QObject, QTimer, QPoint, QEvent, QSettings
+		from PySide.QtCore import Qt, QObject, QTimer, QPoint, QEvent, QSettings, QModelIndex
 		from PySide.QtGui import QMessageBox, QInputDialog, QFileDialog, QMenu, QApplication, QSortFilterProxyModel
 		from PySide.QtGui import QDialog, QMainWindow, QSplashScreen, QShortcut, QItemSelection, QProgressDialog
 		from PySide.QtGui import QStandardItemModel, QStandardItem, QKeySequence, QCursor, QMouseEvent
@@ -45,7 +45,7 @@ except ImportError:
 	except ImportError:
 		from PyQt4 import QtGui, QtCore
 		from PyQt4.QtCore import pyqtSignal as Signal, pyqtSlot as Slot
-		from PyQt4.QtCore import Qt, QObject, QTimer, QPoint, QEvent, QSettings
+		from PyQt4.QtCore import Qt, QObject, QTimer, QPoint, QEvent, QSettings, QModelIndex
 		from PyQt4.QtGui import QMessageBox, QInputDialog, QFileDialog, QMenu, QApplication, QSortFilterProxyModel
 		from PyQt4.QtGui import QDialog, QMainWindow, QSplashScreen, QShortcut, QItemSelection, QProgressDialog
 		from PyQt4.QtGui import QStandardItemModel, QStandardItem, QKeySequence, QCursor, QMouseEvent


### PR DESCRIPTION
Accomplished by making sure all extraction reads QModelIndex values instead of QStandardItems