### PR TITLE
Change "Origin" to "Orig" to match maya's naming convention

### DIFF
--- a/scripts/SimplexUI/tools/mayaTools.py
+++ b/scripts/SimplexUI/tools/mayaTools.py
@@ -500,7 +500,7 @@ def updateRestShape(mesh, newRest):
 	if len(inter) == 1:
 		orig = inter[0]
 	else:
-		origs = [i for i in inter if i.endswith('Origin')]
+		origs = [i for i in inter if i.endswith('Orig')]
 		if len(origs) != 1:
 			return
 		orig = origs[0]


### PR DESCRIPTION
Fixing a misnamed tool