### PR TITLE
Name cascade

### DIFF
--- a/SimplexCPP/src/lib/simplex.h
+++ b/SimplexCPP/src/lib/simplex.h
@@ -101,7 +101,7 @@ class Progression : public ShapeBase {
 	private:
 		std::vector<std::pair<Shape*, double>> pairs;
 		ProgType interp;
-		static size_t getInterval(double tVal, const std::vector<double> &times);
+		static size_t getInterval(double tVal, const std::vector<double> &times, bool &outside);
 		std::vector<std::pair<Shape*, double>> getSplineOutput(double tVal, double mul=1.0) const;
 		std::vector<std::pair<Shape*, double>> getSplitSplineOutput(double tVal, double mul=1.0) const;
 		std::vector<std::pair<Shape*, double>> getLinearOutput(double tVal, double mul=1.0) const;

--- a/scripts/SimplexUI/__init__.py
+++ b/scripts/SimplexUI/__init__.py
@@ -28,19 +28,16 @@ SIMPLEX_UI = None
 SIMPLEX_UI_ROOT = None
 def runSimplexUI():
 	import os, sys
-	import interface
-	import simplexInterfaceDialog
-
+	from .interface import rootWindow, DISPATCH
+	from .simplexInterfaceDialog import SimplexDialog
 	global SIMPLEX_UI
 	global SIMPLEX_UI_ROOT
 
 	# make and show the UI
 	SIMPLEX_UI_ROOT = interface.rootWindow()
 	# Keep a global reference around, otherwise it gets GC'd
-	SIMPLEX_UI = simplexInterfaceDialog.SimplexDialog(
-		parent=SIMPLEX_UI_ROOT, dispatch=interface.DISPATCH)
+	SIMPLEX_UI = SimplexDialog(parent=SIMPLEX_UI_ROOT, dispatch=DISPATCH)
 	SIMPLEX_UI.show()
-
 
 if __name__ == "__main__":
 	import os, sys

--- a/scripts/SimplexUI/__init__.py
+++ b/scripts/SimplexUI/__init__.py
@@ -16,22 +16,29 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 '''
+try:
+	# Check to see if we're at blur b/c we're still stuck on HDF5
+	import blurdev
+except ImportError:
+	OGAWA = True
+else:
+	OGAWA = False
 
 SIMPLEX_UI = None
 SIMPLEX_UI_ROOT = None
 def runSimplexUI():
 	import os, sys
-	import SimplexUI.interface
-	import SimplexUI.simplexInterfaceDialog
+	import interface
+	import simplexInterfaceDialog
 
 	global SIMPLEX_UI
 	global SIMPLEX_UI_ROOT
 
 	# make and show the UI
-	SIMPLEX_UI_ROOT = SimplexUI.interface.rootWindow()
+	SIMPLEX_UI_ROOT = interface.rootWindow()
 	# Keep a global reference around, otherwise it gets GC'd
-	SIMPLEX_UI = SimplexUI.simplexInterfaceDialog.SimplexDialog(
-		parent=SIMPLEX_UI_ROOT, dispatch=SimplexUI.interface.DISPATCH)
+	SIMPLEX_UI = simplexInterfaceDialog.SimplexDialog(
+		parent=SIMPLEX_UI_ROOT, dispatch=interface.DISPATCH)
 	SIMPLEX_UI.show()
 
 

--- a/scripts/SimplexUI/channelBox.py
+++ b/scripts/SimplexUI/channelBox.py
@@ -1,10 +1,10 @@
 #pylint:disable=unused-import,relative-import,missing-docstring,unused-argument,no-self-use
 import os, sys
 
-from SimplexUI.Qt.QtCore import (QAbstractItemModel, QModelIndex, Qt,
+from .Qt.QtCore import (QAbstractItemModel, QModelIndex, Qt,
 					   QObject, Signal, QRectF, QEvent, QTimer)
-from SimplexUI.Qt.QtGui import (QBrush, QColor, QPainter, QPainterPath, QPen, QTextOption, QCursor)
-from SimplexUI.Qt.QtWidgets import (QTreeView, QListView, QApplication, QStyledItemDelegate)
+from .Qt.QtGui import (QBrush, QColor, QPainter, QPainterPath, QPen, QTextOption, QCursor)
+from .Qt.QtWidgets import (QTreeView, QListView, QApplication, QStyledItemDelegate)
 
 from fnmatch import fnmatchcase
 from utils import getNextName, nested

--- a/scripts/SimplexUI/channelBox.py
+++ b/scripts/SimplexUI/channelBox.py
@@ -362,7 +362,7 @@ class ChannelTreeModel(SimplexModel):
 			if isinstance(parent, Group):
 				return parent.items[row]
 			elif parent is None:
-				self.simplex.sliderGroups[row]
+				return self.simplex.sliderGroups[row]
 		except IndexError:
 			pass
 		return None

--- a/scripts/SimplexUI/comboCheckDialog.py
+++ b/scripts/SimplexUI/comboCheckDialog.py
@@ -18,12 +18,59 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 from itertools import combinations, product
-from SimplexUI.Qt import QtCompat
-from SimplexUI.Qt.QtCore import Qt
-from SimplexUI.Qt.QtGui import QBrush, QColor
-from SimplexUI.Qt.QtWidgets import QMessageBox, QListWidgetItem, QDialog
-from SimplexUI.utils import getUiFile
-from SimplexUI.interfaceItems import Combo, Slider
+from .Qt import QtCompat
+from .Qt.QtCore import Qt
+from .Qt.QtGui import QBrush, QColor
+from .Qt.QtWidgets import QMessageBox, QListWidgetItem, QDialog, QTreeWidget, QTreeWidgetItem
+from .utils import getUiFile
+from .interfaceItems import Combo, Slider
+from .dragFilter import DragFilter
+
+class TooManyPossibilitiesError(Exception):
+	pass
+
+def buildPossibleCombos(simplex, sliders, minDepth, maxDepth, lockDict=None, maxPoss=100):
+	""" Build a list of possible combos """
+	# Get the range values for each slider
+	allRanges = {}
+	sliderDict = {}
+	lockDict = lockDict or {}
+
+	for slider in sliders:
+		rng = set(lockDict.get(slider, slider.prog.getRange()))
+		rng.discard(0) # ignore the zeros
+		allRanges[slider] = sorted(rng)
+		sliderDict[slider.name] = slider
+
+	poss = []
+	tooMany = False
+	try:
+		for size in range(minDepth, maxDepth+1):
+			for grp in combinations(sliders, size):
+				names = [i.name for i in grp]
+				ranges = [allRanges[s] for s in grp]
+				for vals in product(*ranges):
+					poss.append(frozenset(zip(names, vals)))
+					if len(poss) > maxPoss:
+						raise TooManyPossibilitiesError("Don't melt your computer")
+	except TooManyPossibilitiesError:
+		tooMany = True
+
+	# Get the "only" combo sets
+	onlys = {}
+	for combo in simplex.combos:
+		sls = [i.slider for i in combo.pairs]
+		if all(r in sliders for r in sls):
+			key = frozenset([(i.slider.name, i.value) for i in combo.pairs])
+			onlys[key] = combo
+
+	toAdd = []
+	for p in poss:
+		truePairs = [(sliderDict[n], v) for n, v in p]
+		toAdd.append((truePairs, onlys.get(p)))
+	return tooMany, toAdd
+
+
 
 
 class ComboCheckItem(QListWidgetItem):
@@ -42,33 +89,103 @@ class ComboCheckItem(QListWidgetItem):
 			self.setForeground(QBrush(QColor(128, 128, 128)))
 
 
-class TooManyPossibilitiesError(Exception):
-	pass
 
 
 class ComboCheckDialog(QDialog):
-	def __init__(self, sliders, parent):
+	''' Dialog for checking what possible combos exist, and picking new combos
+
+	This dialog displays the available combos for a number of input sliders
+
+	In 'Create' mode, it provides a quick way of choosing the one specific combo
+	that the user is looking for
+
+	In 'Check' mode, it provides a convenient way to explore the possibilites
+	and create any missing combos directly
+
+	Arguments:
+		sliders (list): The list of sliders to initialize the dialog with
+		values (list): The list of values that those sliders default to
+			in single mode. Defaults to None
+		mode (str): The mode that the dialog will run. Defaults to 'create'
+		parent (QWidget): The parent for the dialog. Defaults to None
+	'''
+	def __init__(self, sliders, values=None, mode='create', parent=None):
 		super(ComboCheckDialog, self).__init__(parent)
 
 		uiPath = getUiFile(__file__)
 		QtCompat.loadUi(uiPath, self)
-		self.sliders = []
+		self.mode = mode.lower()
 
 		self.uiCreateSelectedBTN.clicked.connect(self.createMissing)
-		self.uiMinLimitSPIN.valueChanged.connect(self.populateWithCheck)
-		self.uiMaxLimitSPIN.valueChanged.connect(self.populateWithCheck)
+		self.uiMinLimitSPIN.valueChanged.connect(self.populateWithoutUpdate)
+		self.uiMaxLimitSPIN.valueChanged.connect(self.populateWithoutUpdate)
 		self.uiCancelBTN.clicked.connect(self.close)
-		self.uiManualUpdateBTN.clicked.connect(self.populateWithCheck)
+		self.uiManualUpdateBTN.clicked.connect(self.populateWithUpdate)
+		self.uiEditTREE.itemChanged.connect(self.populateWithoutUpdate)
+
+		self.dragFilter = DragFilter(self)
+		self.uiEditTREE.viewport().installEventFilter(self.dragFilter)
+		self.dragFilter.dragTick.connect(self.dragTick)
 
 		self.parent().uiSliderTREE.selectionModel().selectionChanged.connect(self.populateWithCheck)
-		self.populateWithUpdate()
+
+		self.valueDict = values or {}
+		self.setSliders(sliders)
+		if self.mode == 'create':
+			self.uiAutoUpdateCHK.setCheckState(Qt.Unchecked)
+			self.uiAutoUpdateCHK.hide()
+			self.uiManualUpdateBTN.hide()
+
+		self.uiMaxLimitSPIN.setValue(max(len(sliders), 2))
+		self.uiMinLimitSPIN.setValue(max(len(sliders)-2, 2))
+
+		if sliders is None:
+			self.populateWithUpdate()
+		else:
+			self._populate()
+
+	def dragTick(self, ticks, mul):
+		''' Deal with the ticks coming from the drag handler '''
+		items = self.uiEditTREE.selectedItems()
+		for item in items:
+			val = item.data(3, Qt.EditRole)
+			val += (0.05) * ticks * mul
+			if abs(val) < 1.0e-5:
+				val = 0.0
+			val = max(min(val, 1.0), -1.0)
+			item.setData(3, Qt.EditRole, val)
+		self.uiEditTREE.viewport().update()
+
+	def setSliders(self, val):
+		self.uiEditTREE.clear()
+		dvs = [None, -1.0, 1.0, 0.5]
+		roles = [Qt.UserRole, Qt.UserRole, Qt.UserRole, Qt.EditRole]
+		val = val or []
+		for slider in val:
+			item = QTreeWidgetItem(self.uiEditTREE, [slider.name])
+			item.setFlags(item.flags() | Qt.ItemIsEditable)
+			vvv = self.valueDict.get(slider, [-1.0, 1.0])
+			mvs = [i for i in vvv if abs(i) != 1.0]
+			mvs = mvs[0] if mvs else 0.5
+
+			item.setData(0, Qt.UserRole, slider)
+			for col in range(1, 4):
+				val = mvs if col == 3 else dvs[col]
+				item.setData(col, roles[col], val)
+				rng = slider.prog.getRange()
+				if val in rng or col == 3:
+					chk = Qt.Checked if val in vvv else Qt.Unchecked
+					item.setCheckState(col, chk)
+
+		for col in reversed(range(4)):
+			self.uiEditTREE.resizeColumnToContents(col)
 
 	def closeEvent(self, event):
 		self.parent().uiSliderTREE.selectionModel().selectionChanged.disconnect(self.populateWithCheck)
 		super(ComboCheckDialog, self).closeEvent(event)
 
 	def populateWithUpdate(self):
-		self.sliders = self.parent().uiSliderTREE.getSelectedItems(typ=Slider)
+		self.setSliders(self.parent().uiSliderTREE.getSelectedItems(typ=Slider))
 		self._populate()
 
 	def populateWithoutUpdate(self):
@@ -76,63 +193,41 @@ class ComboCheckDialog(QDialog):
 
 	def populateWithCheck(self):
 		if self.uiAutoUpdateCHK.isChecked():
-			self.sliders = self.parent().uiSliderTREE.getSelectedItems(typ=Slider)
+			self.setSliders(self.parent().uiSliderTREE.getSelectedItems(typ=Slider))
 		self._populate()
 
 	def _populate(self):
 		""" Populate the list widgets in the UI """
-		# Get the range values for each slider
-		allRanges = {}
-		sliderDict = {}
-
-		if not self.sliders:
-			sliderList = list(self.sliders)
-		else:
-			sliderNames = set([i.name for i in self.sliders])
-			sliderList = []
-			for s in self.sliders:
-				if s.name in sliderNames:
-					sliderList.append(s)
-
-		for slider in sliderList:
-			rng = set(slider.prog.getRange())
-			rng.discard(0) # ignore the zeros
-			allRanges[slider] = sorted(list(rng))
-			sliderDict[slider.name] = slider
-
-		# Build all the slider/value possibility sets
 		minDepth = self.uiMinLimitSPIN.value()
 		maxDepth = self.uiMaxLimitSPIN.value()
+		maxPoss = 100
 
-		maxPoss = 1000
-		poss = []
-		try:
-			for size in range(minDepth, maxDepth+1):
-				for grp in combinations(sliderList, size):
-					names = [i.name for i in grp]
-					ranges = [allRanges[s] for s in grp]
-					for vals in product(*ranges):
-						poss.append(frozenset(zip(names, vals)))
-						if len(poss) > maxPoss:
-							raise TooManyPossibilitiesError("Don't melt your computer")
-		except TooManyPossibilitiesError:
-			self.uiWarningLBL.setText("Too many possibilities. Limiting to {0}".format(maxPoss))
-		else:
-			self.uiWarningLBL.setText("")
+		root = self.uiEditTREE.invisibleRootItem()
+		lockDict = {}
+		sliderList = []
+		roles = [Qt.UserRole, Qt.UserRole, Qt.UserRole, Qt.EditRole]
+		for row in range(root.childCount()):
+			item = root.child(row)
+			slider = item.data(0, Qt.UserRole)
+			if slider is not None:
+				sliderList.append(slider)
+				lv = [item.data(col, roles[col]) for col in range(1, 4) if item.checkState(col)]
+				lockDict[slider] = lv
 
-		# Get the "only" combo sets
-		onlys = {}
-		for combo in self.parent().simplex.combos:
-			sls = [i.slider for i in combo.pairs]
-			if all(r in self.sliders for r in sls):
-				key = frozenset([(i.slider.name, i.value) for i in combo.pairs])
-				onlys[key] = combo
+		tooMany, toAdd = buildPossibleCombos(self.parent().simplex, sliderList, minDepth, maxDepth, lockDict=lockDict, maxPoss=maxPoss)
+
+		lbl = "Too many possibilities. Limiting to {0}".format(maxPoss) if tooMany else ''
+		self.uiWarningLBL.setText(lbl)
 
 		self.uiComboCheckLIST.clear()
-		for p in poss:
-			truePairs = [(sliderDict[n], v) for n, v in p]
-			item = ComboCheckItem(truePairs, onlys.get(p))
+		for pairs, combo in reversed(toAdd):
+			item = ComboCheckItem(pairs, combo)
 			self.uiComboCheckLIST.addItem(item)
+
+		if self.mode == 'create':
+			if self.uiComboCheckLIST.count() > 0:
+				self.uiComboCheckLIST.item(0).setSelected(True)
+
 
 	def createMissing(self):
 		""" Create the missing selected combos """
@@ -147,6 +242,9 @@ class ComboCheckDialog(QDialog):
 				created.append(c)
 
 		self.parent().uiComboTREE.setItemSelection(created)
-		self.populateWithoutUpdate()
+		if self.mode == 'create':
+			self.close()
+		else:
+			self.populateWithoutUpdate()
 
 

--- a/scripts/SimplexUI/commands/alembicCommon.py
+++ b/scripts/SimplexUI/commands/alembicCommon.py
@@ -116,3 +116,31 @@ def getUvArray(imesh):
 		uv = None
 	return uv
 
+def getUvFaces(imesh):
+	''' Get the UV structure for a mesh if it's indexed. If un-indexed, return None
+	This means that if we have valid UVs, but invalid uvFaces, then we're un-indexed
+	and can handle the data appropriately for export without keeping track of index-ness
+	'''
+	sch = imesh.getSchema()
+	rawCounts = sch.getFaceCountsProperty().samples[0]
+	iuvs = sch.getUVsParam()
+	uvFaces = None
+	if iuvs.valid():
+		uvFaces = []
+		uvCounter = 0
+		if iuvs.isIndexed():
+			idxs = list(iuvs.getIndexProperty().getValue())
+			for count in rawCounts:
+				uvFaces.append(list(idxs[uvCounter: uvCounter+count]))
+				uvCounter += count
+	return uvFaces
+
+def getMeshFaces(imesh):
+	rawFaces, rawCounts = getStaticMeshData(imesh)
+	faces = []
+	ptr = 0
+	for count in rawCounts:
+		faces.append(list(rawFaces[ptr: ptr+count]))
+		ptr += count
+	return faces
+

--- a/scripts/SimplexUI/commands/alembicCommon.py
+++ b/scripts/SimplexUI/commands/alembicCommon.py
@@ -110,8 +110,10 @@ def getUvArray(imesh):
 	uvParam = imeshsch.getUVsParam()
 	if uvParam.valid():
 		uvProp = uvParam.getValueProperty()
-		uvValue = uvProp.getValue()
-		uv = OV2fGeomParamSample(uvValue, GeometryScope.kFacevaryingScope)
+		uvVals = uvProp.getValue()
+		uv = zip(uvVals.x, uvVals.y)
+		if np is not None:
+			uv = np.array(uv)
 	else:
 		uv = None
 	return uv

--- a/scripts/SimplexUI/commands/correctiveInterface.py
+++ b/scripts/SimplexUI/commands/correctiveInterface.py
@@ -20,7 +20,7 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 import blurdev
 from applyCorrectives import loadJSString
 from alembic.Abc import IArchive
-from SimplexUI.Qt.QtWidgets import QApplication
+from ..Qt.QtWidgets import QApplication
 import numpy as np
 
 try:

--- a/scripts/SimplexUI/commands/expandedExport.py
+++ b/scripts/SimplexUI/commands/expandedExport.py
@@ -1,0 +1,350 @@
+from alembic.AbcGeom import OXform, OPolyMesh, OPolyMeshSchemaSample, OV2fGeomParamSample, GeometryScope
+from alembic.Abc import OArchive, OStringProperty
+
+from ..interfaceItems import Slider, Combo, Traversal
+from ..mayaInterface import disconnected
+from .alembicCommon import mkSampleVertexPoints
+from .. import OGAWA
+
+import maya.OpenMaya as om
+from imath import V2fArray, V3fArray, IntArray, UnsignedIntArray
+from ctypes import c_float
+import numpy as np
+from pysimplex import PySimplex
+
+def getShape(mesh):
+	''' Get the np.array shape of the mesh connected to the smpx '''
+	# This should probably be rolled into the DCC code
+	sl = om.MSelectionList()
+	sl.add(mesh)
+	thing = om.MDagPath()
+	sl.getDagPath(0, thing)
+	meshFn = om.MFnMesh(thing)
+	rawPts = meshFn.getRawPoints()
+	ptCount = meshFn.numVertices()
+	cta = (c_float * ptCount * 3).from_address(int(rawPts))
+	out = np.ctypeslib.as_array(cta)
+	out = np.copy(out)
+	out = out.reshape((-1, 3))
+	return out
+
+def getAbcFaces(mesh):
+	# Get the MDagPath from the name of the mesh
+	sl = om.MSelectionList()
+	sl.add(mesh)
+	thing = om.MDagPath()
+	sl.getDagPath(0, thing)
+	meshFn = om.MFnMesh(thing)
+
+	faces = []
+	faceCounts = []
+	#uvArray = []
+	uvIdxArray = []
+	vIdx = om.MIntArray()
+
+	util = om.MScriptUtil()
+	util.createFromInt(0)
+	uvIdxPtr = util.asIntPtr()
+	uArray = om.MFloatArray()
+	vArray = om.MFloatArray()
+	meshFn.getUVs(uArray, vArray)
+	hasUvs = uArray.length() > 0
+
+	for i in range(meshFn.numPolygons()):
+		meshFn.getPolygonVertices(i, vIdx)
+		face = []
+		for j in reversed(xrange(vIdx.length())):
+			face.append(vIdx[j])
+			if hasUvs:
+				meshFn.getPolygonUVid(i, j, uvIdxPtr)
+				uvIdx = util.getInt(uvIdxPtr)
+				if uvIdx >= uArray.length() or uvIdx < 0:
+					uvIdx = 0
+				uvIdxArray.append(uvIdx)
+
+		face = [vIdx[j] for j in reversed(xrange(vIdx.length()))]
+		faces.extend(face)
+		faceCounts.append(vIdx.length())
+
+	abcFaceIndices = IntArray(len(faces))
+	for i in xrange(len(faces)):
+		abcFaceIndices[i] = faces[i]
+
+	abcFaceCounts = IntArray(len(faceCounts))
+	for i in xrange(len(faceCounts)):
+		abcFaceCounts[i] = faceCounts[i]
+
+	if hasUvs:
+		abcUVArray = V2fArray(len(uArray))
+		for i in xrange(len(uArray)):
+			abcUVArray[i] = (uArray[i], vArray[i])
+		abcUVIdxArray = UnsignedIntArray(len(uvIdxArray))
+		for i in xrange(len(uvIdxArray)):
+			abcUVIdxArray[i] = uvIdxArray[i]
+		uv = OV2fGeomParamSample(abcUVArray, abcUVIdxArray, GeometryScope.kFacevaryingScope)
+	else:
+		uv = None
+
+	return abcFaceIndices, abcFaceCounts, uv
+
+def _setSliders(ctrl, val, svs):
+	slis, vals = svs.setdefault(ctrl.simplex, ([], []))
+
+	if isinstance(ctrl, Slider):
+		slis.append(ctrl)
+		vals.append(val)
+	elif isinstance(ctrl, Combo):
+		for cp in ctrl.pairs:
+			slis.append(cp.slider)
+			vals.append(cp.value * abs(val))
+	elif isinstance(ctrl, Traversal):
+		# set the ctrl.multiplierCtrl.controller to 1
+		multCtrl = ctrl.multiplierCtrl.controller
+		multVal = ctrl.multiplierCtrl.value if val != 0.0 else 0.0
+		progCtrl = ctrl.progressCtrl.controller
+		progVal = ctrl.progressCtrl.value
+		_setSliders(multCtrl, multVal, svs)
+		_setSliders(progCtrl, val, svs)
+
+def setSliderGroup(ctrls, val):
+	svs = {}
+	for ctrl in ctrls:
+		_setSliders(ctrl, val, svs)
+
+	for smpx, (slis, vals) in svs.iteritems():
+		smpx.setSlidersWeights(slis, vals)
+
+def clientPartition(master, clients):
+	sliders, combos, traversals = {}, {}, {}
+	for cli in [master] + clients:
+		for sli in cli.sliders:
+			sliders.setdefault(sli.name, []).append(sli)
+
+		for com in cli.combos:
+			combos.setdefault(com.name, []).append(com)
+
+		for trav in cli.traversals:
+			traversals.setdefault(trav.name, []).append(trav)
+	return sliders, combos, traversals
+
+def zeroAll(smpxs):
+	for smpx in smpxs:
+		smpx.setSlidersWeights(smpx.sliders, [0.0] * len(smpx.sliders))
+
+def getExpandedData(master, clients, mesh):
+	''' Get the fully expanded shape data for each slider, combo, and traversal
+	at each of its underlying shapes '''
+	# zero everything
+	zeroAll([master] + clients)
+	sliPart, cmbPart, travPart = clientPartition(master, clients)
+	sliderShapes = {}
+	for slider in master.sliders:
+		ss = {}
+		sliderShapes[slider] = ss
+		for pp in slider.prog.pairs:
+			if pp.shape.isRest:
+				continue
+			setSliderGroup(sliPart[slider.name], pp.value)
+			ss[pp] = getShape(mesh)
+			setSliderGroup(sliPart[slider.name], 0.0)
+
+	# Disable traversals
+	zeroAll([master] + clients)
+	travShapeThings = []
+	comboShapes = {}
+	for trav in master.traversals:
+		for pp in trav.prog.pairs:
+			if pp.shape.isRest:
+				continue
+			travShapeThings.append(pp.shape)
+	travShapeThings = [i.thing for i in travShapeThings]
+
+	# Get the combos with traversals disconnected
+	with disconnected(travShapeThings):
+		for combo in master.combos:
+			ss = {}
+			comboShapes[combo] = ss
+			for pp in combo.prog.pairs:
+				if pp.shape.isRest:
+					continue
+				setSliderGroup(cmbPart[combo.name], pp.value)
+				ss[pp] = getShape(mesh)
+				setSliderGroup(cmbPart[combo.name], 0.0)
+
+	zeroAll([master] + clients)
+	travShapes = {}
+	for trav in master.traversals:
+		ss = {}
+		travShapes[trav] = ss
+		progCtrl = trav.progressCtrl.controller
+		progVal = trav.progressCtrl.value
+		for pp in progCtrl.prog.pairs:
+			if pp.shape.isRest:
+				continue
+			if pp.value * progVal <= 0.0:
+				# Traversals only activate if the progression is in the same
+				# pos/neg direction as the value. Otherwise we just skip
+				continue
+
+			setSliderGroup(travPart[trav.name], pp.value)
+			ss[pp] = getShape(mesh)
+			setSliderGroup(travPart[trav.name], 0.0)
+
+	zeroAll([master] + clients)
+	restShape = getShape(mesh)
+
+	return restShape, sliderShapes, comboShapes, travShapes
+
+def _setInputs(inVec, item, indexBySlider, value):
+	''' Being clever
+	Sliders or Combos just set the value and return
+	Traversals recursively call this function with the controllers (that only either sliders or combos)
+	'''
+	if isinstance(item, Slider):
+		inVec[indexBySlider[item]] = value
+		return inVec
+	elif isinstance(item, Combo):
+		for pair in item.pairs:
+			inVec[indexBySlider[pair.slider]] = pair.value * abs(value)
+		return inVec
+	elif isinstance(item, Traversal):
+		inVec = _setInputs(inVec, item.multiplierCtrl.controller, indexBySlider, item.multiplierCtrl.value)
+		inVec = _setInputs(inVec, item.progressCtrl.controller, indexBySlider, item.progressCtrl.value * value)
+		return inVec
+	raise ValueError("Not a Slider, Combo, or Traversal. Got type {0}: {1}".format(type(item), item))
+
+def _buildSolverInputs(simplex, item, value, indexBySlider):
+	'''
+	Build an input vector for the solver that will
+	produce a required progression value on an item
+	'''
+	inVec = [0.0] * len(simplex.sliders)
+	return _setInputs(inVec, item, indexBySlider, value)
+
+def getTravDepth(trav):
+	inputs = []
+	mult = trav.multiplierCtrl.controller
+	prog = trav.progressCtrl.controller
+	for item in (mult, prog):
+		if isinstance(item, Slider):
+			inputs.append(item)
+		elif isinstance(item, Combo):
+			for cp in item.pairs:
+				inputs.append(cp.slider)
+	return len(set(inputs))
+
+def parseExpandedData(smpx, restShape, sliderShapes, comboShapes, travShapes):
+	''' Turn the expanded data into shapeDeltas connected to the actual Shape objects '''
+	solver = PySimplex(smpx.dump())
+	shapeArray = np.zeros((len(smpx.shapes), len(restShape), 3))
+
+	indexBySlider = {s: i for i, s in enumerate(smpx.sliders)}
+	indexByShape = {s: i for i, s in enumerate(smpx.shapes)}
+
+	floatShapeSet = set(smpx.getFloatingShapes())
+	floatIdxs = sorted(set([indexByShape[s] for s in floatShapeSet]))
+	travShapeSet = set([pp.shape for t in smpx.traversals for pp in t.prog.pairs])
+	travIdxs = sorted(set([indexByShape[s] for s in travShapeSet]))
+
+	# Sliders are simple, just set their shapes directly
+	for ppDict in sliderShapes.itervalues():
+		for pp, shp in ppDict.iteritems():
+			shapeArray[indexByShape[pp.shape]] = shp - restShape
+
+	# First sort the combos by depth
+	comboByDepth = {}
+	for combo in smpx.combos:
+		comboByDepth.setdefault(len(combo.pairs), []).append(combo)
+
+	for depth in sorted(comboByDepth.keys()):
+		for combo in comboByDepth[depth]:
+			for pp, shp in comboShapes[combo].iteritems():
+				inVec = _buildSolverInputs(smpx, combo, pp.value, indexBySlider)
+				outVec = np.array(solver.solve(inVec))
+				outVec[np.where(np.isclose(outVec, 0.0))] = 0.0
+				outVec[np.where(np.isclose(outVec, 1.0))] = 1.0
+				outVec[indexByShape[pp.shape]] = 0.0
+
+				# ignore any traversals
+				outVec[travIdxs] = 0.0
+
+				# ignore floaters if we're not currently checking floaters
+				if pp.shape not in floatShapeSet:
+					outVec[floatIdxs] = 0.0
+
+				# set the shape delta to the output
+				baseShape = np.dot(outVec, shapeArray.swapaxes(0, 1))
+				shapeArray[indexByShape[pp.shape]] = shp - restShape - baseShape
+
+	# First the traversals by depth
+	travByDepth = {}
+	for trav in smpx.traversals:
+		travByDepth.setdefault(getTravDepth(trav), []).append(trav)
+
+	for depth in sorted(travByDepth.keys()):
+		for trav in travByDepth[depth]:
+			for pp, shp in travShapes[trav].iteritems():
+				inVec = _buildSolverInputs(smpx, trav, pp.value, indexBySlider)
+				outVec = np.array(solver.solve(inVec))
+				outVec[np.where(np.isclose(outVec, 0.0))] = 0.0
+				outVec[np.where(np.isclose(outVec, 1.0))] = 1.0
+				outVec[indexByShape[pp.shape]] = 0.0
+
+				# set the shape delta to the output
+				baseShape = np.dot(outVec, shapeArray.swapaxes(0, 1))
+				shapeArray[indexByShape[pp.shape]] = shp - restShape - baseShape
+	return shapeArray
+
+def buildShapeArray(mesh, master, clients):
+	restShape, sliderShapes, comboShapes, travShapes = getExpandedData(master, clients, mesh)
+	shapeArray = parseExpandedData(master, restShape, sliderShapes, comboShapes, travShapes)
+	shapeArray += restShape[None, ...]
+	return shapeArray
+
+def _exportAbc(arch, smpx, shapeArray, faces, counts, uvs):
+	par = OXform(arch.getTop(), str(smpx.name))
+	props = par.getSchema().getUserProperties()
+	prop = OStringProperty(props, "simplex")
+	prop.setValue(str(smpx.dump()))
+	abcMesh = OPolyMesh(par, str(smpx.name))
+	schema = abcMesh.getSchema()
+	for i in range(len(smpx.shapes)):
+		if uvs is not None:
+			abcSample = OPolyMeshSchemaSample(mkSampleVertexPoints(shapeArray[i]), faces, counts, uvs)
+		else:
+			# can't just pass uvs as None because of how the Alembic API works
+			abcSample = OPolyMeshSchemaSample(mkSampleVertexPoints(shapeArray[i]), faces, counts)
+		schema.set(abcSample)
+
+def expandedExportAbc(path, mesh, master, clients=()):
+	''' Export the alembic by re-building the deltas from all of the full shapes
+	This is required for delta-mushing a system, because the sum of mushed shapes
+	is not the same as the mushed sum-of-shapes
+	'''
+	# Convert clients to a list if need be
+	if not clients:
+		clients = []
+	elif not isinstance(clients, list):
+		if isinstance(clients, tuple):
+			clients = list(clients)
+		else:
+			clients = [clients]
+
+	faces, counts, uvs = getAbcFaces(mesh)
+	shapeArray = buildShapeArray(mesh, master, clients)
+
+	# export the data to alembic
+	arch = OArchive(str(path), OGAWA) # alembic does not like unicode filepaths
+	try:
+		_exportAbc(arch, master, shapeArray, faces, counts, uvs)
+	finally:
+		del arch
+
+
+if __name__ == "__main__":
+	# get the smpx from the UI
+	master = Simplex.buildSystemFromMesh('Face_SIMPLEX', 'Face')
+	client = Simplex.buildSystemFromMesh('Face_SIMPLEX2', 'Face2')
+	outPath = r'D:\Users\tyler\Desktop\TEST\expanded.smpx'
+	expandedExportAbc(outPath, 'Face_SIMPLEX', master, client)
+

--- a/scripts/SimplexUI/commands/hdf5Convert.py
+++ b/scripts/SimplexUI/commands/hdf5Convert.py
@@ -68,7 +68,7 @@ def loadMesh(iarch):
 
 	return faces, counts
 
-def hdf5Convert(inPath, outPath):
+def hdf5Convert(inPath, outPath, ogawa=False):
 	''' Load and parse all the data from a simplex file '''
 	if not os.path.isfile(str(inPath)):
 		raise IOError("File does not exist: " + str(inPath))
@@ -78,7 +78,7 @@ def hdf5Convert(inPath, outPath):
 	faces, counts = loadMesh(iarch)
 	del iarch
 
-	oarch = OArchive(str(outPath), False) # alembic does not like unicode filepaths
+	oarch = OArchive(str(outPath), ogawa) # alembic does not like unicode filepaths
 	try:
 		_writeSimplex(oarch, 'Face', jsString, faces, counts, shapes)
 	finally:
@@ -86,7 +86,7 @@ def hdf5Convert(inPath, outPath):
 		gc.collect()
 
 if __name__ == '__main__':
-	inPath = r'D:\Users\tyler\Desktop\highresSimplex_BadOrder_Ogawa.smpx'
-	outPath = r'D:\Users\tyler\Desktop\highresSimplex_BadOrder_hdf5.smpx'
-	hdf5Convert(inPath, outPath)
+	inPath = r'D:\Users\tyler\Desktop\Head_Morphs_Main_Head-Face_v0010.smpx'
+	outPath = r'D:\Users\tyler\Desktop\Head_ogawa.smpx'
+	hdf5Convert(inPath, outPath, ogawa=True)
 

--- a/scripts/SimplexUI/commands/mayaCorrectiveInterface.py
+++ b/scripts/SimplexUI/commands/mayaCorrectiveInterface.py
@@ -17,8 +17,10 @@ You should have received a copy of the GNU Lesser General Public License
 along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-from maya import cmds #pylint:disable=import-error,wrong-import-position
+from maya import cmds
+from maya import OpenMaya as om
 import numpy as np
+from ctypes import c_float
 
 def setPose(pvp, multiplier):
 	''' Set a percentage of a pose '''
@@ -30,18 +32,37 @@ def resetPose(pvp):
 	for prop, val in pvp:
 		cmds.setAttr(prop, 0)
 
+def _getDagPath(mesh):
+	sl = om.MSelectionList()
+	sl.add(mesh)
+	dagPath = om.MDagPath()
+	sl.getDagPath(0, dagPath)
+	return dagPath
+
+def _getMayaPoints(meshFn):
+	rawPts = meshFn.getRawPoints()
+	ptCount = meshFn.numVertices()
+	cta = (c_float * 3 * ptCount).from_address(int(rawPts))
+	out = np.ctypeslib.as_array(cta)
+	out = np.copy(out)
+	out = out.reshape((-1, 3))
+	return out
+
 def getShiftValues(thing):
 	''' Get the rest and 1-move arrays from a thing '''
+	dp = _getDagPath(thing)
+	meshFn = om.MFnMesh(dp)
 	allVerts = '{0}.vtx[*]'.format(thing)
 
-	zero = np.array(cmds.xform(allVerts, translation=1, query=1)).reshape((-1, 3))
+	zero = _getMayaPoints(meshFn)
 	cmds.move(1, 0, 0, allVerts, relative=1, objectSpace=1)
-	oneX = np.array(cmds.xform(allVerts, translation=1, query=1)).reshape((-1, 3))
+	oneX = _getMayaPoints(meshFn)
 	cmds.move(-1, 1, 0, allVerts, relative=1, objectSpace=1)
-	oneY = np.array(cmds.xform(allVerts, translation=1, query=1)).reshape((-1, 3))
+	oneY = _getMayaPoints(meshFn)
 	cmds.move(0, -1, 1, allVerts, relative=1, objectSpace=1)
-	oneZ = np.array(cmds.xform(allVerts, translation=1, query=1)).reshape((-1, 3))
+	oneZ = _getMayaPoints(meshFn)
 	cmds.move(0, 0, -1, allVerts, relative=1, objectSpace=1)
 
 	return zero, oneX, oneY, oneZ
+
 

--- a/scripts/SimplexUI/commands/reorderSimplexPoints.py
+++ b/scripts/SimplexUI/commands/reorderSimplexPoints.py
@@ -37,6 +37,7 @@ from alembicCommon import mkSampleVertexPoints, mkSampleIntArray, getSampleArray
 
 import numpy as np
 from imathnumpy import arrayToNumpy #pylint:disable=no-name-in-module
+from .. import OGAWA
 
 def loadJSString(iarch):
 	''' Get the json string out of a .smpx file '''
@@ -118,7 +119,7 @@ def reorderSimplexPoints(sourcePath, matchPath, outPath, invertMatch=False):
 	faces = mkSampleIntArray(ci[sFaces])
 
 	print "Writing"
-	oarch = OArchive(str(outPath)) # alembic does not like unicode filepaths
+	oarch = OArchive(str(outPath), OGAWA) # alembic does not like unicode filepaths
 	try:
 		_writeSimplex(oarch, 'Face', jsString, faces, counts, targetShapes)
 	finally:

--- a/scripts/SimplexUI/commands/smpxBlend.py
+++ b/scripts/SimplexUI/commands/smpxBlend.py
@@ -1,0 +1,449 @@
+import blurdev
+print "AE", blurdev.activeEnvironment()
+
+import copy
+from SimplexUI.interfaceItems import Simplex, Group, Traversal, Combo, Slider, Shape, Falloff, ProgPair, ComboPair, TravPair, Progression
+import numpy as np
+
+class Skip(object): pass # an extra "none-ish" object to signify completely skipping the un-matched shape
+
+def smpxMismatchCheck(simpA, simpB):
+	mmDict = {}
+
+	#saShapeNames = {sa.name: sa for sa in simpA.shapes}
+	#sbShapeNames = {sb.name: sb for sb in simpB.shapes}
+	#saShapeNameUnique = saShapeNames.viewkeys() - sbShapeNames.viewkeys()
+	#sbShapeNameUnique = sbShapeNames.viewkeys() - saShapeNames.viewkeys()
+	#slnMatch = [(san, None) for san in saShapeNameUnique] + [(None, sbn) for sbn in sbShapeNameUnique]
+	#mmDict['shape'] = slnMatch
+
+	saSliderNames = {sa.name: sa for sa in simpA.sliders}
+	sbSliderNames = {sb.name: sb for sb in simpB.sliders}
+	saSliderNameUnique = saSliderNames.viewkeys() - sbSliderNames.viewkeys()
+	sbSliderNameUnique = sbSliderNames.viewkeys() - saSliderNames.viewkeys()
+	slnMatch = {}
+	for san in saSliderNameUnique:
+		slnMatch[san] = (san, None)
+	for sbn in sbSliderNameUnique:
+		slnMatch[sbn] = (None, sbn)
+	mmDict['slider'] = slnMatch
+
+	saComboNames = {sa.name: sa for sa in simpA.combos}
+	sbComboNames = {sb.name: sb for sb in simpB.combos}
+	saComboNameUnique = saComboNames.viewkeys() - sbComboNames.viewkeys()
+	sbComboNameUnique = sbComboNames.viewkeys() - saComboNames.viewkeys()
+	# TODO search for combos with mis-ordered inputs
+	cnMatch = {}
+	for can in saComboNameUnique:
+		cnMatch[can] = (can, None)
+	for cbn in sbComboNameUnique:
+		cnMatch[cbn] = (None, cbn)
+	mmDict['combo'] = cnMatch
+
+	saTravNames = {sa.name: sa for sa in simpA.traversals}
+	sbTravNames = {sb.name: sb for sb in simpB.traversals}
+	saTravNameUnique = saTravNames.viewkeys() - sbTravNames.viewkeys()
+	sbTravNameUnique = sbTravNames.viewkeys() - saTravNames.viewkeys()
+	# TODO search for travs with mis-ordered inputs
+	tnMatch = {}
+	for tan in saTravNameUnique:
+		tnMatch[tan] = (tan, None)
+	for tbn in sbTravNameUnique:
+		tnMatch[tbn] = (None, tbn)
+	mmDict['traversal'] = tnMatch
+
+	return mmDict
+	
+
+def orderedMerge(va, vb):
+	# come up with a better way that keeps some of the input structure
+	return sorted(set(va) | set(vb))
+
+
+# Falloffs
+def mergeFalloffs(simpA, simpB, outSimp, translation, nameOnly=True):
+	if not nameOnly:
+		raise ValueError("Not implemented yet")
+	aNames = [f.name for f in simpA.falloffs]
+	aDict = dict(zip(aNames, simpA.falloffs))
+	bNames = [f.name for f in simpB.falloffs]
+	bDict = dict(zip(bNames, simpB.falloffs))
+	oNames = orderedMerge(aNames, bNames)
+	for oName in oNames:
+		baseFo = aDict.get(oName, bDict[oName])
+		if baseFo.splitType == 'planar':
+			data = (
+				baseFo.splitType, baseFo.axis, baseFo.maxVal,
+				baseFo.maxHandle, baseFo.minHandle, baseFo.minVal
+			)
+		else:
+			data = (baseFo.splitType, baseFo.mapName)
+		fo = Falloff(oName, outSimp, *data)
+		translation[aDict.get(oName)] = fo
+		translation[bDict.get(oName)] = fo
+
+
+# Groups
+def _mergeGroupSubset(aTypedGroups, bTypedGroups, outSimp, gType, translation):
+	asG = [g.name for g in aTypedGroups]
+	bsG = [g.name for g in bTypedGroups]
+	asGDict = dict(zip(asG, aTypedGroups))
+	bsGDict = dict(zip(bsG, bTypedGroups))
+	osG = orderedMerge(asG, bsG)
+	for groupName in osG:
+		newGroup = Group(groupName, outSimp, gType)
+		translation[asGDict.get(groupName)] = newGroup
+		translation[bsGDict.get(groupName)] = newGroup
+
+def mergeGroups(simpA, simpB, outSimp, translation):
+	_mergeGroupSubset(simpA.sliderGroups, simpB.sliderGroups, outSimp, Slider, translation) 
+	_mergeGroupSubset(simpA.comboGroups, simpB.comboGroups, outSimp, Combo, translation)
+	_mergeGroupSubset(simpA.traversalGroups, simpB.traversalGroups, outSimp, Traversal, translation)
+
+
+
+# Shapes
+def _blendShape(aShape, bShape, outSimp, blendVal, translation):
+	if aShape in translation or bShape in translation:
+		return translation.get(aShape, translation[bShape])
+
+	newShape = Shape(aShape.name, outSimp, create=True)
+
+	aDeltas = aShape.verts - aShape.simplex.restShape.verts
+	bDeltas = bShape.verts - bShape.simplex.restShape.verts
+	deltas = aDeltas*(1.0 - blendVal) + bDeltas*blendVal
+	newShape.verts = outSimp.restShape.verts + deltas
+
+	translation[aShape] = newShape
+	translation[bShape] = newShape
+	return newShape
+
+def _copyShape(shape, outSimp, translation, deltaOverride=None):
+	if shape in translation:
+		return translation[shape]
+	newShape = Shape(shape.name, outSimp, create=True)
+
+	if deltaOverride is None:
+		deltas = shape.verts - shape.simplex.restShape.verts
+		newShape.verts = outSimp.restShape.verts + deltas
+	else:
+		newShape.verts = deltaOverride
+
+	translation[shape] = newShape
+	return newShape
+
+
+
+
+# Progs
+def _deltaProg(shape, srcMin, srcMax, tarMin, tarMax, tVal):
+	srcExtDelta = tVal * (srcMax.verts - srcMin.verts)
+	srcShpDelta = shape.verts - srcMin.verts
+	srcOffset = srcShpDelta - srcExtDelta
+	ret = tVal*(tarMax.verts - tarMin.verts) + srcOffset
+	return ret
+
+def _blendProg(aProg, bProg, outSimp, blendVal, translation):
+	''' Progressions don't necessarily have the same number of shapes, or the same ranges
+	So we try to be smart here.
+	Any shapes with the same value are blended by blendVal
+	Any extreme values (-1, or 1) are copied over
+	Any progressive values are copied as deltas off the extreme
+	'''
+	aVals = [float(pp.value) for pp in aProg.pairs]
+	bVals = [float(pp.value) for pp in bProg.pairs]
+	commonVals = sorted(set(aVals) & set(bVals))
+	aUniq = set(aVals) - set(commonVals)
+	bUniq = set(bVals) - set(commonVals)
+	aValDict = dict(zip(aVals, aProg.pairs))
+	bValDict = dict(zip(bVals, bProg.pairs))
+
+	# First handle all the common values
+	outValDict = {}
+	for c in commonVals:
+		newShape = _blendShape(aValDict[c].shape, bValDict[c].shape, outSimp, blendVal, translation)
+		outValDict[c] = newShape
+
+	# Then handle any unique extremes
+	if 1.0 in aUniq:
+		outValDict[1.0] = _copyShape(aValDict[1.0].shape, outSimp, translation)
+	if -1.0 in aUniq:
+		outValDict[-1.0] = _copyShape(aValDict[-1.0].shape, outSimp, translation)
+	if 1.0 in bUniq:
+		outValDict[1.0] = _copyShape(bValDict[1.0].shape, outSimp, translation)
+	if -1.0 in bUniq:
+		outValDict[-1.0] = _copyShape(bValDict[-1.0].shape, outSimp, translation)
+
+	# Finally handle the unique progressions as deltas off the extremes
+	outRest = outValDict[0.0]
+	aRest = aValDict[0.0].shape
+	for c in aUniq:
+		aShp = aValDict[c].shape
+		mm = 1.0 if c > 0.0 else -1.0
+		dd =_deltaProg(aShp, aRest, aValDict[mm].shape, outRest, outValDict[mm], mm * c)
+		outValDict[c] = _copyShape(aShp, outSimp, translation, deltaOverride=dd)
+
+	bRest = bValDict[0.0].shape
+	for c in bUniq:
+		bShp = bValDict[c].shape
+		mm = 1.0 if c > 0.0 else -1.0
+		dd =_deltaProg(bShp, bRest, bValDict[mm].shape, outRest, outValDict[mm], mm * c)
+		outValDict[c] = _copyShape(bShp, outSimp, translation, deltaOverride=dd)
+
+	outPairs = [ProgPair(outSimp, outValDict[val], val) for val in sorted(outValDict.keys())]
+	prog = Progression(aProg.name, outSimp, pairs=outPairs, interp=aProg.interp)
+	translation[aProg] = prog
+	translation[bProg] = prog
+	return prog
+
+def _copyProg(prog, outSimp, translation):
+	pairs = []
+	for pp in prog.pairs:
+		newShape = _copyShape(pp.shape, outSimp, translation)
+		pair = ProgPair(outSimp, newShape, pp.value)
+		pairs.append(pair)
+	outProg = Progression(prog.name, outSimp, pairs=pairs, interp=prog.interp)
+	translation[prog] = outProg
+	return outProg
+
+
+
+# Sliders
+def _blendSliders(aSlider, bSlider, outSimp, blendVal, translation):
+	if aSlider in translation or bSlider in translation:
+		return translation.get(aSlider, translation[bSlider])
+		
+	group = translation.get(aSlider.group, translation[bSlider.group])
+	prog = _blendProg(aSlider.prog, bSlider.prog, outSimp, blendVal, translation)
+	outSlider = Slider(aSlider.name, outSimp, prog, group)
+	translation[aSlider] = outSlider
+	translation[bSlider] = outSlider
+	return outSlider
+
+def _copySlider(slider, outSimp, translation):
+	if slider in translation:
+		return translation[slider]
+
+	group = translation[slider.group]
+	prog = _copyProg(slider.prog, outSimp, translation)
+	outSlider = Slider(slider.name, outSimp, prog, group)
+	translation[slider] = outSlider
+	return outSlider
+	
+def sliderBlend(simpA, simpB, outSimp, blendVal, translation, mismatch):
+	aNames = [s.name for s in simpA.sliders]
+	aDict = dict(zip(aNames, simpA.sliders))
+	bNames = [s.name for s in simpB.sliders]
+	bDict = dict(zip(bNames, simpB.sliders))
+	oNames = orderedMerge(aNames, bNames)
+
+	for oIdx, oName in enumerate(oNames):
+		print "Copying Slider {0} of {1}: {2}".format(oIdx, len(oNames), oName)
+		aName, bName = mismatch['slider'].get(oName, (oName, oName))
+		if aName is Skip or bName is Skip:
+			continue
+		elif aName is None:
+			_copySlider(bDict[bName], outSimp, translation)
+		elif bName is None:
+			_copySlider(aDict[aName], outSimp, translation)
+		else:
+			_blendSliders(aDict[aName], bDict[bName], outSimp, blendVal, translation)
+
+
+
+# Combos
+def _blendCombos(aCombo, bCombo, outSimp, blendVal, translation):
+	if aCombo in translation or bCombo in translation:
+		return translation.get(aCombo, translation[bCombo])
+
+	group = translation.get(aCombo.group, translation[bCombo.group])
+
+	cPairs = []
+	for aPair, bPair in zip(aCombo.pairs, bCombo.pairs):
+		slider = _blendSliders(aPair.slider, bPair.slider, outSimp, blendVal, translation)
+		cPairs.append(ComboPair(slider, aPair.value))
+	
+	prog = _blendProg(aCombo.prog, bCombo.prog, outSimp, blendVal, translation)
+	outCombo = Combo(aCombo.name, outSimp, cPairs, prog, group, aCombo.solveType)
+	translation[aCombo] = outCombo
+	translation[bCombo] = outCombo
+	return outCombo
+
+def _copyCombo(combo, outSimp, translation):
+	if combo in translation:
+		return translation[combo]
+	group = translation[combo.group]
+
+	cPairs = []
+	for pair in combo.pairs:
+		slider = _copySlider(pair.slider, outSimp, translation)
+		cPairs.append(ComboPair(slider, pair.value))
+	prog = _copyProg(combo.prog, outSimp, translation)
+	
+	outCombo = Combo(combo.name, outSimp, cPairs, prog, group, combo.solveType)
+	translation[combo] = outCombo
+	return outCombo
+
+def comboBlend(simpA, simpB, outSimp, blendVal, translation, mismatch):
+	aNames = [s.name for s in simpA.combos]
+	aDict = dict(zip(aNames, simpA.combos))
+	bNames = [s.name for s in simpB.combos]
+	bDict = dict(zip(bNames, simpB.combos))
+	oNames = orderedMerge(aNames, bNames)
+
+	for oIdx, oName in enumerate(oNames):
+		print "Copying Combo {0} of {1}: {2}".format(oIdx, len(oNames), oName)
+		aName, bName = mismatch['combo'].get(oName, (oName, oName))
+
+		if oName in mismatch:
+			print "Getting", oName
+			print "Mismatch Get", oName in mismatch, aName, bName
+
+		if aName is Skip or bName is Skip:
+			continue
+		elif aName is None:
+			_copyCombo(bDict[bName], outSimp, translation)
+		elif bName is None:
+			_copyCombo(aDict[aName], outSimp, translation)
+		else:
+			_blendCombos(aDict[aName], bDict[bName], outSimp, blendVal, translation)
+
+
+
+# Traversals
+def _blendController(aItem, bItem, outSimp, blendVal, translation):
+	aCtrl = aItem.controller
+	bCtrl = bItem.controller
+
+	if isinstance(aCtrl, Slider):
+		ctrl = _blendSliders(aCtrl, bCtrl, outSimp, blendVal, translation)
+	elif isinstance(aCtrl, Combo):
+		ctrl = _blendCombos(aCtrl, bCtrl, outSimp, blendVal, translation)
+	else:
+		raise ValueError("Bad object type: {0} {1}".format(aCtrl, type(aCtrl)))
+	return TravPair(ctrl, aItem.value, aItem.usage)
+
+def _copyController(item, outSimp, translation):
+	iCtrl = item.controller
+	if isinstance(iCtrl, Slider):
+		ctrl = _copySlider(iCtrl, outSimp, translation)
+	elif isinstance(iCtrl, Combo):
+		ctrl = _copyCombo(iCtrl, outSimp, translation)
+	else:
+		raise ValueError("Bad object type: {0} {1}".format(iCtrl, type(iCtrl)))
+	return TravPair(ctrl, item.value, item.usage)
+
+
+def _blendTraversals(aTrav, bTrav, outSimp, blendVal, translation):
+	group = translation.get(aTrav.group, translation[bTrav.group])
+	multCtrl = _blendController(aTrav.multiplierCtrl, bTrav.multiplierCtrl, outSimp, blendVal, translation)
+	progCtrl = _blendController(aTrav.progressCtrl, bTrav.progressCtrl, outSimp, blendVal, translation)
+	prog = _blendProg(aTrav.prog, bTrav.prog, outSimp, blendVal, translation)
+	outTrav = Traversal(aTrav.name, outSimp, multCtrl, progCtrl, prog, group)
+	translation[aTrav] = outTrav
+	translation[bTrav] = outTrav
+	return outTrav
+
+def _copyTraversal(traversal, outSimp, translation):
+	group = translation[traversal.group]
+	multCtrl = _copyController(traversal.multiplierCtrl, outSimp, translation)
+	progCtrl = _copyController(traversal.progressCtrl, outSimp, translation)
+	prog = _copyProg(traversal.prog, outSimp, translation)
+	outTrav = Traversal(traversal.name, outSimp, multCtrl, progCtrl, prog, group)
+	translation[traversal] = outTrav
+	return outTrav
+
+def traversalBlend(simpA, simpB, outSimp, blendVal, translation, mismatch):
+	aNames = [s.name for s in simpA.traversals]
+	aDict = dict(zip(aNames, simpA.traversals))
+	bNames = [s.name for s in simpB.traversals]
+	bDict = dict(zip(bNames, simpB.traversals))
+	oNames = orderedMerge(aNames, bNames)
+
+	for oIdx, oName in enumerate(oNames):
+		print "Copying Traversal {0} of {1}: {2}".format(oIdx, len(oNames), oName)
+		aName, bName = mismatch['traversal'].get(oName, (oName, oName))
+		if aName is Skip or bName is Skip:
+			continue
+		elif aName is None:
+			_copyTraversal(bDict[bName], outSimp, translation)
+		elif bName is None:
+			_copyTraversal(aDict[aName], outSimp, translation)
+		else:
+			_blendTraversals(aDict[aName], bDict[bName], outSimp, blendVal, translation)
+
+
+
+# Simplex
+def smpxBlend(simpA, simpB, blendVal=0.50, mismatchDict=None, name='Face'):
+	'''
+	Blend the deltas from simplexA and simplexB. Apply the output to simplexA
+	Equal falloffs will be combined. Others will be given suffixes
+	'''
+	mismatchDict = mismatchDict or {}
+	simpA.stack.enabled = False
+	simpB.stack.enabled = False
+
+	outSimp = Simplex(name=name, forceDummy=True)
+	outSimp.stack.enabled = False
+
+	dcc = outSimp.DCC
+	dcc._faces = simpA.DCC._faces
+	dcc._counts = simpA.DCC._counts
+	dcc._uvs = simpA.DCC._uvs
+	dcc._falloffs = simpA.DCC._falloffs
+	dcc._numVerts = simpA.DCC._numVerts
+
+	rest = Shape.buildRest(outSimp)
+	rest.verts = simpA.restShape.verts*(1-blendVal) + simpB.restShape.verts*blendVal
+
+	outSimp.restShape = rest
+
+	# When walking through this smpx file, keep a "translation" dictionary 
+	# where translation[InputObjectID] = OutputObject
+	translation = {}
+	translation[simpA.restShape] = rest
+	translation[simpB.restShape] = rest
+
+	# Merge the groups. This one is easy. Merge by name
+	mergeGroups(simpA, simpB, outSimp, translation)
+	
+	# Merge the falloffs. We can either require them to have equal values to "merge"
+	# Or we can just merge by name. The nameOnly kwarg handles this. True for now
+	mergeFalloffs(simpA, simpB, outSimp, translation, nameOnly=True)
+
+	# Copying one of the "big" object types should create and blend its child prog and shapes
+	print "Copying Sliders"
+	sliderBlend(simpA, simpB, outSimp, blendVal, translation, mismatchDict)
+	print "Copying Combos"
+	comboBlend(simpA, simpB, outSimp, blendVal, translation, mismatchDict)
+	print "Copying Traversals"
+	traversalBlend(simpA, simpB, outSimp, blendVal, translation, mismatchDict)
+
+	# push the verts to the dummy dcc for later export
+	dcc.pushAllShapeVertices(outSimp.shapes)
+	return outSimp
+
+
+if __name__ == "__main__":
+	pathA = r'D:\Users\tyler\Desktop\TEST\GumboA.smpx'
+	pathB = r'D:\Users\tyler\Desktop\TEST\GumboB.smpx'
+	outPath = r'D:\Users\tyler\Desktop\TEST\hoping2.smpx'
+
+	print "Loading SimpA"
+	simpA = Simplex.buildSystemFromSmpx(pathA, forceDummy=True)
+	print "Loading SimpB"
+	simpB = Simplex.buildSystemFromSmpx(pathB, forceDummy=True)
+
+	print "Matching A:B"
+	mismatch = smpxMismatchCheck(simpA, simpB)
+	outSmpx = smpxBlend(simpA, simpB, blendVal=0.5, mismatchDict=mismatch)
+	
+	print "Exporting"
+	print "OUT SMPX", outSmpx
+	outSmpx.exportAbc(outPath)
+
+
+	print "DONE"
+
+

--- a/scripts/SimplexUI/commands/unsubdivide.py
+++ b/scripts/SimplexUI/commands/unsubdivide.py
@@ -6,6 +6,7 @@ Move the vertices so a new subdivision will match the
 original as closely as possible
 """
 import json
+import numpy as np
 from itertools import chain, izip_longest
 
 from alembic.Abc import IArchive, OArchive, OStringProperty
@@ -13,7 +14,8 @@ from alembic.AbcGeom import IPolyMesh, OPolyMesh, IXform, OXform, OPolyMeshSchem
 
 from alembicCommon import mkSampleVertexPoints, getSampleArray, getMeshFaces, getUvFaces, getUvArray, mkSampleIntArray, mkUvSample
 
-from SimplexUI.Qt.QtWidgets import QApplication
+from ..Qt.QtWidgets import QApplication
+from .. import OGAWA
 
 def mergeCycles(groups):
 	"""
@@ -790,8 +792,6 @@ def pbPrint(pBar, message=None, val=None, _pbPrintLastComma=[]):
 				print message
 	QApplication.processEvents()
 
-
-# TODO: In the future, allow for shape repositioning instead of just deletion
 def _ussmpx(faces, verts, uvFaces, uvs, pBar=None):
 	pbPrint(pBar, "Finding Neighbors")
 	eNeigh = buildEdgeDict(faces)
@@ -842,7 +842,7 @@ def _applyShapePrefix(shapePrefix, jsString):
 	return jsString
 
 def _exportUnsub(outPath, xfoName, meshName, jsString, faces, verts, uvFaces, uvs, pBar=None):
-	oarch = OArchive(str(outPath), False) # False for HDF5
+	oarch = OArchive(str(outPath), OGAWA) # False for HDF5
 	oxfo = OXform(oarch.getTop(), xfoName)
 	oprops = oxfo.getSchema().getUserProperties()
 	oprop = OStringProperty(oprops, "simplex")
@@ -885,12 +885,5 @@ def unsubdivideSimplex(inPath, outPath, shapePrefix=None, pBar=None):
 	uvs = getUvArray(imesh)
 	uFaces, uVerts, uUVFaces, uUVs = _ussmpx(faces, verts, uvFaces, uvs, pBar=pBar)
 	_exportUnsub(outPath, xfoName, meshName, jsString, uFaces, uVerts.swapaxes(0, 1), uUVFaces, uUVs, pBar=pBar)
-
-
-if __name__ == "__main__":
-	inPath = r''
-	outPath = r''
-	unsubdivideSimplex(inPath, outPath, shapePrefix=None)
-
 
 

--- a/scripts/SimplexUI/commands/unsubdivide.py
+++ b/scripts/SimplexUI/commands/unsubdivide.py
@@ -1,258 +1,833 @@
-'''
-Copyright 2016, Blur Studio
-
-This file is part of Simplex.
-
-Simplex is free software: you can redistribute it and/or modify
-it under the terms of the GNU Lesser General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-Simplex is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public License
-along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
-'''
-
+#pylint: disable=unused-argument, too-many-locals
+#pylint:disable=E0611,E0401
 """
-Do a simple unsubdivision of the input simplex.
-Basically, I just delete the unused vertices and edges. I *don't* try to
-re-create what the input geometry would have been before subdividing, I'm
-just making it easy to get a quick low-res mesh for animation use.
+Remove a subdivision level from a mesh's topology, and
+Move the vertices so a new subdivision will match the
+original as closely as possible
 """
 import json
+from itertools import chain, izip_longest
 
 from alembic.Abc import IArchive, OArchive, OStringProperty
 from alembic.AbcGeom import IPolyMesh, OPolyMesh, IXform, OXform, OPolyMeshSchemaSample
 
-from alembicCommon import mkSampleVertexPoints, getSampleArray, mkArray
-from imath import IntArray
+from alembicCommon import mkSampleVertexPoints, getSampleArray, getMeshFaces, getUvFaces, getUvArray, mkSampleIntArray, mkUvSample
 
 from SimplexUI.Qt.QtWidgets import QApplication
 
-def parseAbc(path):
-	""" Read an .abc file and produce a Mesh object
-
-	Args:
-		path: The path to the .abc formatted file
-
-	Returns:
-		A list of vertices and the face connectivity
-
-	Raises:
-		IOError: If the file cannot be opened
+def mergeCycles(groups):
 	"""
+	Take a list of ordered items, and sort them so the
+	last item of a list matches the first of the next list
+	Then return the groups of lists mashed together
+	for instance, with two cycles:
+		input:   [(1, 2), (11, 12), (3, 1), (10, 11), (2, 3), (12, 10)]
+		reorder: [[(1, 2), (2, 3), (3, 1)], [(10, 11), (11, 12), (12, 13)]]
+		output:  [[1, 2, 3], [10, 11, 12, 13]]
 
-	iarch = IArchive(str(path)) # because alembic hates unicode
-	top = iarch.getTop()
-	ixfo = IXform(top, top.children[0].getName())
-	mesh = IPolyMesh(ixfo, ixfo.children[0].getName())
+	Also, return whether the cycles merged form a single closed group
+	"""
+	groups = [list(g) for g in groups]
+	heads = {g[0]:g for g in groups}
+	tails = {g[-1]:g for g in groups}
 
-	sch = mesh.getSchema()
-	rawVerts = sch.getPositionsProperty().samples[0]
-	rawFaces = sch.getFaceIndicesProperty().samples[0]
-	rawCounts = sch.getFaceCountsProperty().samples[0]
+	headGetter = lambda x: heads.get(x[-1])
+	headSetter = lambda x, y: x + y[1:]
 
-	faces = []
-	faceCounter = 0
-	for count in rawCounts:
-		f = list(rawFaces[faceCounter: faceCounter+count])
-		# Ignoring UV/Normal data for now
-		faces.append(f)
-		faceCounter += count
+	tailGetter = lambda x: tails.get(x[0])
+	tailSetter = lambda x, y: y + x[1:]
 
-	verts = []
-	for v in rawVerts:
-		verts.append(list(v))
+	searches = ((headGetter, headSetter), (tailGetter, tailSetter))
 
-	return verts, faces
+	out = []
+	cycles = []
+	while groups:
+		g = groups.pop()
+		del heads[g[0]]
+		del tails[g[-1]]
 
-def buildEdgeAdjacency(faces):
-	''' Build a dictionary with vert indices as keys,
-	and a list of edge-adjacent vert indices as the value
-	'''
-	adj = {}
-	for face in faces:
-		for i in range(len(face)):
-			adj.setdefault(face[i], set()).add(face[i-1])
-			adj.setdefault(face[i-1], set()).add(face[i])
-	return adj
+		for getter, setter in searches:
+			while True:
+				adder = getter(g)
+				if adder is None:
+					break
+				g = setter(g, adder)
+				del heads[adder[0]]
+				del tails[adder[-1]]
+				adder[:] = []
+			groups = [x for x in groups if x]
 
-def buildDiagonalAdjacency(faces):
-	''' Build a dictionary with vert indices as keys,
-	and a list of quad-diagonal vert indices as the value
-	'''
-	adj = {}
-	for face in faces:
-		if len(face) != 4:
-			continue
-		for i in range(len(face)):
-			adj.setdefault(face[i], set()).add(face[i-2])
-			adj.setdefault(face[i-2], set()).add(face[i])
-	return adj
+		cycle = False
+		if g[0] == g[-1]:
+			g.pop()
+			cycle = True
+		cycles.append(cycle)
+		out.append(g)
+	return out, cycles
 
-def growByAdjacency(growSet, exclude, adj):
-	''' Grow a set of verts along an adjacency dict
-	Args:
-		growSet: A set of Vertices to grow.
-		exclude: A set of Vertices to exclude from
-			the growth
-
-	Returns:
-		newGrowSet: the grown verts
-		newExclude: the next set of verts to exclude
-	'''
+def grow(neigh, verts, exclude):
+	""" Grow the vertex set, also keeping track
+	of which vertices we can safely ignore for
+	the next iteration
+	"""
 	grown = set()
-	for vert in growSet:
-		grown.update(adj.get(vert, []))
-	newgrown = grown - exclude
-	newexclude = exclude | growSet
-	return newgrown, newexclude
+	growSet = verts - exclude
+	for v in growSet:
+		grown.update(neigh[v])
+	newGrown = grown - exclude
+	newExclude = exclude | growSet
+	return newGrown, newExclude
 
-def partitionVerts(hints, adj, diag):
-	''' Partition a subdivided mesh's vertices into
-	originals , Added edge verts, and added center verts
-	'''
-	originals = set(hints)
-	centers = set()
-	exclude = set(hints)
-
-	while True:
-		newCorners, exclude = growByAdjacency(originals, exclude, diag)
-		if not newCorners:
-			break
-		centers.update(newCorners)
-
-		newCenters, exclude = growByAdjacency(centers, exclude, diag)
-		if not newCenters:
-			break
-		originals.update(newCenters)
-
-	edges, exc = growByAdjacency(originals, exclude, adj)
-
-	if edges & centers:
-		raise ValueError("The input mesh was not a perfect subdivision")
-
-	return originals, edges, centers
-
-def buildNewFaces(faces, centers, diag):
-	''' Build a new set of faces by removing
-	center verts and the adjacent edgeVerts
-	'''
-	faceIdxsByVert = {}
-	for i, face in enumerate(faces):
-		for f in face:
-			faceIdxsByVert.setdefault(f, set()).add(i)
-
-	newFaces = []
-	for center in centers:
-		corners = diag[center]
-		centerFaceIdxs = faceIdxsByVert[center]
-
-		newFace = []
-		c = corners.pop()
-		while c not in newFace:
-			newFace.append(c)
-			cornerFaceIdxs = faceIdxsByVert[c] & centerFaceIdxs
-			cornerFaceIdx = cornerFaceIdxs.pop()
-			face = faces[cornerFaceIdx]
-
-			pre = face[face.index(c) - 1]
-			edgeFaceIdxs = faceIdxsByVert[pre] & centerFaceIdxs
-			edgeFaceIdxs.remove(cornerFaceIdx)
-			preFaceIdx = edgeFaceIdxs.pop()
-			preFace = faces[preFaceIdx]
-
-			c = preFace[preFace.index(pre) - 1]
-		newFace.reverse()
-		newFaces.append(newFace)
-
-	return newFaces
-
-def squashFaces(faces):
-	''' Take a list of unsubdivided faces and
-	squash the indices into a continuous range
-	'''
-	kept = set()
-	for f in faces:
-		kept |= set(f)
-	kept = sorted(list(kept))
-
-	# build the reverse accessor
-	rev = {k: i for i, k in enumerate(kept)}
-
-	newFaces = []
-	for face in faces:
-		nf = []
-		for f in face:
-			nf.append(rev[f])
-		newFaces.append(nf)
-
-	return newFaces, kept
-
-def findBoundaryVerts(adj, diag):
-	''' Return a list of Vertices along the edge of a mesh '''
-	edges = []	
-	keys = list(set(adj.keys() + diag.keys()))
-	for k in keys:
-		if len(adj[k]) == 3 and len(diag[k]) == 2:
-			edges.append(k)
-		elif len(adj[k]) == 2 and len(diag[k]) == 1:
-			edges.append(k)
-	return edges
-
-def partitionIslands(adj, numVerts):
-	''' Return a list of connected island sets '''
-	allVerts = set(range(numVerts))
-	islands = []
-	while allVerts:
-		seed = set([allVerts.pop()])
-		island = set()
-		while seed:
-			seed, island = growByAdjacency(seed, island, adj)
-		islands.append(island)
-		allVerts.difference_update(island)
-	return islands
-
-def buildHints(island, edges, adj):
-	''' Find star points that are an even number of grows from an edge '''
-	edgeSet = set(edges)
-	boundaries = island  & edgeSet
-	if not boundaries:
+def buildHint(island, neigh, borders):
+	""" Find star points that are an even number of grows from an edge """
+	borders = borders & island
+	if not borders:
 		# Well ... we don't have any good way of dealing with this
-		# Best thing I can do is search for the highest valence verts
-		# and use one of those as the hint.
+		# Best thing I can do is search for a point with the least
+		# number of similar valences, and return that
 		d = {}
 		for v in island:
-			d.setdefault(len(adj[v]), []).append(v)
-		mkey = max(d.keys())
-		return d[mkey][0]
+			d.setdefault(len(neigh[v]), []).append(v)
+
+		dd = {}
+		for k, v in d.iteritems():
+			dd.setdefault(len(v), []).append(k)
+
+		mkey = min(dd.keys())
+		return d[dd[mkey][0]][0]
 
 	exclude = set()
-	while boundaries:
-		for b in boundaries:
-			if len(adj[b]) != 4:
-				if b not in edgeSet:
-					return b
-		boundaries, exclude = growByAdjacency(boundaries, exclude, adj)
-		boundaries, exclude = growByAdjacency(boundaries, exclude, adj)
-	raise ValueError("Somehow, a mesh has boundaries, but no vert with a non-4 valence")
+	while borders:
+		borders, exclude = grow(neigh, borders, exclude)
+		borders, exclude = grow(neigh, borders, exclude)
+		for b in borders:
+			if len(neigh[b]) != 4:
+				return b
+	return None
+
+def partitionIslands(faces, neigh, pBar=None):
+	""" Find all groups of connected verts """
+	allVerts = set(chain.from_iterable(faces))
+	islands = []
+	count = float(len(allVerts))
+	while allVerts:
+		verts = set([allVerts.pop()])
+		exclude = set()
+		while verts:
+			verts, exclude = grow(neigh, verts, exclude)
+		islands.append(exclude)
+		allVerts.difference_update(exclude)
+
+		if pBar is not None:
+			pBar.setValue(100 * (count - len(allVerts)) / count)
+			QApplication.processEvents()
+
+	return islands
+
+def buildUnsubdivideHints(faces, neigh, borders, pBar=None):
+	""" Get one vertex per island that was part of the original mesh """
+	islands = partitionIslands(faces, neigh, pBar=pBar)
+	hints = []
+
+	if pBar is not None:
+		pBar.setValue(0)
+		pBar.setMaximum(len(islands))
+		QApplication.processEvents()
+
+	for i, isle in enumerate(islands):
+		if pBar is not None:
+			pBar.setValue(i)
+			QApplication.processEvents()
+		hints.append(buildHint(isle, neigh, borders))
+
+	hints = [h for h in hints if h is not None]
+	return hints
+
+def getFaceCenterDel(faces, eNeigh, hints, pBar=None):
+	"""
+	Given a list of hint "keeper" points
+	Return a list of points that were created at the
+	centers of the original faces during a subdivision
+	"""
+	vertToFaces = {}
+	vc = set()
+	for i, face in enumerate(faces):
+		for f in face:
+			vertToFaces.setdefault(f, []).append(i)
+			vc.add(f)
+
+	count = float(len(vc))
+	centers = set()
+	midpoints = set()
+	originals = set(hints)
+	queue = set(hints)
+
+	if pBar is not None:
+		pBar.setValue(0)
+		pBar.setMaximum(count)
+		QApplication.processEvents()
+
+	i = 0
+	fail = False
+	while queue:
+		cur = queue.pop()
+		if cur in midpoints:
+			continue
+
+		if pBar is not None:
+			pBar.setValue(i)
+			QApplication.processEvents()
+			i += 2 # Add 2 because I *shouldn't* get any midpoints
+
+		midpoints.update(eNeigh[cur])
+		t = centers if cur in originals else originals
+
+		for f in vertToFaces[cur]:
+			nVerts = faces[f]
+
+			if len(nVerts) != 4:
+				fail = True
+				continue
+
+			curFaceIndex = nVerts.index(cur)
+
+			half = int(len(nVerts) / 2)
+			diag = nVerts[curFaceIndex - half]
+
+			isOrig = diag in originals
+			isCtr = diag in centers
+			if not isOrig and not isCtr:
+				t.add(diag)
+				queue.add(diag)
+			elif (isCtr and t is originals) or (isOrig and t is centers) or (diag in midpoints):
+				fail = True
+
+	return centers, fail
+
+def getBorders(faces):
+	"""
+	Arguments:
+		faces ([[vIdx, ...], ...]): A face representation
+
+	Returns:
+		set : A set of vertex indexes along the border of the mesh
+	"""
+	edgePairs = set()
+	for face in faces:
+		for f in range(len(face)):
+			edgePairs.add((face[f], face[f-1]))
+	borders = set()
+	for ep in edgePairs:
+		if (ep[1], ep[0]) not in edgePairs:
+			borders.update(ep)
+	return borders
+
+def buildEdgeDict(faces):
+	"""
+	Arguments:
+		faces ([[vIdx, ...], ...]): A face representation
+
+	Returns:
+		{vIdx: [vIdx, ...]}: A dictionary keyed from a vert index whose
+			values are adjacent edges
+	"""
+	edgeDict = {}
+	for face in faces:
+		for f in range(len(face)):
+			ff = edgeDict.setdefault(face[f-1], set())
+			ff.add(face[f])
+			ff.add(face[f-2])
+	return edgeDict
+
+def buildNeighborDict(faces):
+	"""
+	Build a structure to ask for edge and face neighboring vertices
+	The returned neighbor list starts with an edge neighbor, and
+	proceeds counter clockwise, alternating between edge and face neighbors
+	Also, while I'm here, grab the border verts
+
+	Arguments:
+		faces ([[vIdx, ...], ...]): A face representation
+
+	Returns:
+		{vIdx: [[vIdx, ...], ...]}: A dictionary keyed from a vert index whose
+			values are ordered cycles or fans
+		set(vIdx): A set of vertices that are on the border
+	"""
+	fanDict = {}
+	edgeDict = {}
+	for face in faces:
+		for i in range(len(face)):
+			fanDict.setdefault(face[i], []).append(face[i+1:] + face[:i])
+			ff = edgeDict.setdefault(face[i-1], set())
+			ff.add(face[i])
+			ff.add(face[i-2])
+
+	borders = set()
+	out = {}
+	for k, v in fanDict.iteritems():
+		fans, cycles = mergeCycles(v)
+		for f, c in zip(fans, cycles):
+			if not c:
+				borders.update((f[0], f[-1], k))
+		out[k] = fans
+	return out, edgeDict, borders
+
+def _fanMatch(fan, uFan, dWings):
+	""" Twist a single fan so it matches the uFan if it can """
+	uIdx = uFan[0]
+	for f, fIdx in enumerate(fan):
+		dw = dWings.get(fIdx, [])
+		if uIdx in dw:
+			return fan[f:] + fan[:f]
+	return None
+
+def _align(neigh, uNeigh, dWings):
+	""" Twist all the neighs so they match the uNeigh """
+	out = []
+	for uFan in uNeigh:
+		for fan in neigh:
+			fm = _fanMatch(fan, uFan, dWings)
+			if fm is not None:
+				out.append(fm)
+				break
+	return out
+
+def buildLayeredNeighborDicts(faces, uFaces, dWings):
+	"""
+	Build and align two neighbor dicts
+	for both faces and uFaces which guarantees that the
+	neighbors at the same index are analogous (go in the same direction)
+	"""
+	neighDict, edgeDict, borders = buildNeighborDict(faces)
+	uNeighDict, uEdgeDict, uBorders = buildNeighborDict(uFaces)
+
+	assert borders >= uBorders, "Somehow the unsubdivided borders contain different vIdxs"
+
+	for i, (k, uNeigh) in enumerate(uNeighDict.iteritems()):
+		neighDict[k] = _align(neighDict[k], uNeigh, dWings)
+
+	return neighDict, uNeighDict, edgeDict, uEdgeDict, borders
+
+def _findOldPositionBorder(faces, uFaces, verts, uVerts, neighDict, uNeighDict, edgeDict, uEdgeDict, borders, vIdx, computed):
+	"""
+	This is the case where vIdx is on the mesh border
+	Updates uVerts in-place
+	Arguments:
+		faces ([[vIdx ...], ...]): The subdivided face structure
+		uFaces ([[vIdx ...], ...]): The unsubdivided face structure
+		verts (np.array): The subdivided vertex positions
+		uVerts (np.array): The unsubdivided vertex positions
+		neighDict ({vIdx:[[vIdx, ...], ...]}): Dictionary of neighbor "fans"
+		uNeighDict ({vIdx:[[vIdx, ...], ...]}): Dictionary of neighbor "fans"
+		vIdx (int): The vertex position to check
+		computed (set): A set of vIdxs that have been computed
+	"""
+	nei = neighDict[vIdx][0]
+	nei = [i for i in nei if i in borders]
+	assert len(nei) == 2, "Found multi border, {}".format(nei)
+	uVerts[vIdx] = 2*verts[vIdx] - ((verts[nei[0]] + verts[nei[1]]) / 2)
+	computed.add(vIdx)
+
+def _findOldPositionSimple(faces, uFaces, verts, uVerts, neighDict, uNeighDict, edgeDict, uEdgeDict, vIdx, computed):
+	"""
+	This is the simple case where vIdx has valence >= 4
+	Updates uVerts in-place
+	Arguments
+		faces ([[vIdx ...], ...]): The subdivided face structure
+		uFaces ([[vIdx ...], ...]): The unsubdivided face structure
+		verts (np.array): The subdivided vertex positions
+		uVerts (np.array): The unsubdivided vertex positions
+		neighDict ({vIdx:[[vIdx, ...], ...]}): Dictionary of neighbor "fans"
+		uNeighDict ({vIdx:[[vIdx, ...], ...]}): Dictionary of neighbor "fans"
+		vIdx (int): The vertex position to check
+		computed (set): A set of vIdxs that have been computed
+	"""
+	neigh = neighDict[vIdx][0]
+
+	eTest = edgeDict[vIdx]
+	e = [p for p in neigh if p in eTest]
+	f = [p for p in neigh if p not in eTest]
+
+	es = verts[e].sum(axis=0)
+	fs = verts[f].sum(axis=0)
+
+	n = len(e)
+	term1 = verts[vIdx] * (n / (n-3.0))
+	term2 = es * (4 / (n*(n-3.0)))
+	term3 = fs * (1 / (n*(n-3.0)))
+	vk = term1 - term2 + term3
+
+	uVerts[vIdx] = vk
+	computed.add(vIdx)
+
+def _findOldPosition3Valence(faces, uFaces, verts, uVerts, neighDict, uNeighDict, edgeDict, uEdgeDict, vIdx, computed):
+	"""
+	This is the complex case where vIdx has valence == 3
+	Updates uVerts in-place
+	Arguments
+		faces ([[vIdx ...], ...]): The subdivided face structure
+		uFaces ([[vIdx ...], ...]): The unsubdivided face structure
+		verts (np.array): The subdivided vertex positions
+		uVerts (np.array): The unsubdivided vertex positions
+		neighDict ({vIdx:[[vIdx, ...], ...]}): Dictionary of neighbor "fans"
+		uNeighDict ({vIdx:[[vIdx, ...], ...]}): Dictionary of neighbor "fans"
+		vIdx (int): The vertex position to check
+		computed (set): A set of vIdxs that have been computed
+
+	Returns:
+		bool: Whether an update happened
+
+	"""
+	neigh = neighDict[vIdx][0]
+	uNeigh = uNeighDict[vIdx][0]
+
+	eTest = edgeDict[vIdx]
+	eNeigh = [n for n in neigh if n in eTest]
+	fNeigh = [n for n in neigh if n not in eTest]
+
+	ueTest = uEdgeDict[vIdx]
+	ueNeigh = [n for n in uNeigh if n in ueTest]
+	#ufNeigh = [n for n in uNeigh if n not in ueTest]
+
+	intr = computed.intersection(ueNeigh)
+	if intr:
+		# Easy valence 3 case. I only need
+		# The computed new neighbor
+		# The midpoint on the edge to that neighbor
+		# The "face" verts neighboring the midpoint
+
+		# Get the matching subbed an unsubbed neighbor indexes
+		uNIdx = intr.pop()
+		nIdx = eNeigh[ueNeigh.index(uNIdx)]
+
+		# Get the "face" verts next to the subbed neighbor
+		xx = neigh.index(nIdx)
+		fnIdxs = (neigh[xx-1], neigh[(xx+1)%len(neigh)])
+
+		# Then compute
+		#vk = 4*k1e - ke - k1fNs[0] - k1fNs[1]
+		vka = uVerts[uNIdx] + verts[fnIdxs[0]] + verts[fnIdxs[1]]
+		vkb = verts[nIdx] * 4
+		uVerts[vIdx] = vkb - vka
+		computed.add(vIdx)
+		return True
+
+	else:
+		# The Hard valence 3 case. Made even harder
+		# because the paper has a mistake in it
+
+		# vk = 4*ejk1 + 4*ejpk1 - fjnk1 - fjpk1 - 6*fjk1 + sum(fik)
+		# where k1 means subdivided mesh
+		# where j means an index, jn and jp are next/prev adjacents
+		# sum(fik) is the sum of all the points of the face that
+		#     *aren't* the original, or edge-adjacent
+		#     There could be more than 1 if an n-gon was subdivided
+		#
+		# I wonder: If it was a triangle that was subdivided, what
+		# would sum(fik) because there are no verts that fit that
+		# description.  I think this is a degenerate case
 
 
-# TODO Make this work with UV's 
-def exportUnsub(inPath, outPath, newFaces, kept, shapePrefix=None, pBar=None):
-	''' Export the unsubdivided simplex '''
+		# First, find an adjacent face on the unsub mesh that
+		# is only missing the neighbors of the vIdx
+
+		fnIdx = None
+		fik = None
+		fCtrIdx = None
+		for x, v in enumerate(fNeigh):
+			# working with neigh, but should only ever contain uNeigh indexes
+			eTest = edgeDict[vIdx]
+			origFace = set([n for n in neighDict[v][0] if n not in eTest])
+
+			check = (origFace - set(ueNeigh)) - set([vIdx])
+			if computed >= check:
+				fCtrIdx = v
+				fnIdx = x
+				fik = sorted(list(check))
+				break
+
+		if fnIdx is None:
+			# No possiblity found
+			return False
+
+		# Then apply the equation from above
+		neighIdx = neigh.index(fCtrIdx)
+		ejnk1 = neigh[(neighIdx+1)%len(neigh)]
+		ejpk1 = neigh[neighIdx-1]
+		fjnk1 = fNeigh[(fnIdx+1)%len(fNeigh)]
+		fjpk1 = fNeigh[fnIdx-1]
+		fjk1 = verts[fCtrIdx]
+		sumFik = uVerts[fik].sum(axis=0)
+		vk = 4*ejnk1 + 4*ejpk1 - fjnk1 - fjpk1 - 6*fjk1 + sumFik
+		uVerts[vIdx] = vk
+		computed.add(vIdx)
+		return True
+	return False
+
+def deleteCenters(meshFaces, uvFaces, centerDel, pBar=None):
+	"""
+	Delete the given vertices and connected edges from a face representation
+	to give a new representation.
+
+	Arguments:
+		meshFaces ([[vIdx, ...], ...]): Starting mesh representation
+		centerDel ([vIdx, ...]): The vert indices to delete.
+
+	Returns:
+		TODO
+
+	"""
+	# For each deleted index, grab the neighboring faces,
+	# and twist the faces so the deleted index is first
+	cds = set(centerDel)
+	faceDelDict = {}
+	uvDelDict = {}
+	uvFaces = uvFaces or []
+	for face, uvFace in izip_longest(meshFaces, uvFaces):
+		fi = cds.intersection(face)
+		# If we are a subdivided mesh, Then each face will have exactly one
+		# vertex that is part of the deletion set
+		if len(fi) != 1:
+			raise ValueError("Found a face with an unrecognized connectivity")
+		# Get that one vert
+		idx = fi.pop()
+		# Each face is a cycle. Rotate the cycle
+		# so that idx is first in the list
+		rv = face.index(idx)
+		rFace = face[rv:] + face[:rv]
+		faceDelDict.setdefault(idx, []).append(rFace)
+
+		if uvFace is not None:
+			rUVFace = uvFace[rv:] + uvFace[:rv]
+			uvDelDict.setdefault(idx, []).append(rUVFace)
+
+	newFaces = []
+	nUVFaces = []
+	wings = {}
+	uvWings = {}
+
+	if pBar is not None:
+		pBar.setValue(0)
+		pBar.setMaximum(len(faceDelDict))
+
+	chk = -1
+	for idx, rFaces in faceDelDict.iteritems():
+		chk += 1
+		if pBar is not None:
+			pBar.setValue(chk)
+			QApplication.processEvents()
+
+		ruvFaces = uvDelDict.get(idx, [])
+		# The faces are guaranteed to be in a single loop cycle
+		# so I don't have to handle any annoying edge cases! Yay!
+		faceEnds = {f[1]: (f[2], f[3], uvf) for f, uvf in izip_longest(rFaces, ruvFaces)} #face ends
+
+		end = rFaces[-1][-1] # get an arbitrary face to start with
+		newFace = []
+		nUVFace = []
+		while faceEnds:
+			try:
+				diag, nxt, uvf = faceEnds.pop(end)
+			except KeyError:
+				print "rFaces", rFaces
+				print "fe", faceEnds
+				raise
+			if uvf is not None:
+				try:
+					nUVFace.append(uvf[2])
+					uvWings.setdefault(uvf[1], []).append(uvf[2])
+					uvWings.setdefault(uvf[3], []).append(uvf[2])
+				except IndexError:
+					print "UVF", uvf, chk
+					raise
+
+			newFace.append(diag)
+			wings.setdefault(end, []).append(diag)
+			wings.setdefault(nxt, []).append(diag)
+
+			end = nxt
+		newFaces.append(newFace)
+		if nUVFace:
+			nUVFaces.append(nUVFace)
+	nUVFaces = nUVFaces or None
+
+	return newFaces, nUVFaces, wings, uvWings
+
+def fixVerts(faces, uFaces, verts, neighDict, uNeighDict, edgeDict, uEdgeDict, borders, pinned, pBar=None):
+	"""
+	Given the faces, vertex positions, and the point indices that
+	were created at the face centers for a subdivision step
+	Return the faces and verts of the mesh from before the
+	subdivision step. This algorithm doesn't handle UV's yet
+
+	Arguments:
+		faces ([[vIdx, ...], ...]): A face topology representation
+		verts (np.array): An array of vertex positions
+		centerDel ([vIdx, ..]): A list 'face center' vertices
+
+	Returns:
+		[[vIdx, ...], ...]: A non-compact face topology representation
+		np.array: An array of vertex positions
+	"""
+	uVerts = verts.copy()
+	uIdxs = sorted(list(set([i for i in chain.from_iterable(uFaces)])))
+
+	v3Idxs = []
+	# bowtie verts are pinned
+	bowTieIdxs = []
+	computed = set()
+	i = 0
+	if pBar is not None:
+		pBar.setValue(0)
+		pBar.setMaximum(len(uIdxs))
+
+	for idx in uIdxs:
+		if pBar is not None:
+			pBar.setValue(i)
+			QApplication.processEvents()
+		if len(uNeighDict[idx]) > 1:
+			bowTieIdxs.append(idx)
+			i += 1
+		elif idx in pinned:
+			pass
+		elif idx in borders:
+			_findOldPositionBorder(faces, uFaces, verts, uVerts, neighDict, uNeighDict, edgeDict, uEdgeDict, borders, idx, computed)
+			i += 1
+		elif sum(map(len, neighDict[idx])) > 6: # if valence > 3
+			_findOldPositionSimple(faces, uFaces, verts, uVerts, neighDict, uNeighDict, edgeDict, uEdgeDict, idx, computed)
+			i += 1
+		else:
+			v3Idxs.append(idx)
+
+	updated = True
+	while updated:
+		updated = False
+		rem = set()
+		for idx in v3Idxs:
+			up = _findOldPosition3Valence(faces, uFaces, verts, uVerts, neighDict, uNeighDict, edgeDict, uEdgeDict, idx, computed)
+			if not up:
+				continue
+			if pBar is not None:
+				pBar.setValue(i)
+				QApplication.processEvents()
+			i += 1
+			updated = True
+			rem.add(idx)
+		v3Idxs = list(set(v3Idxs) - rem)
+
+	return uVerts
+
+def getUVPins(faces, borders, uvFaces, uvBorders, pinBorders):
+	"""Find which uvBorders are also mesh borders"""
+	if uvFaces is None: return set()
+	if pinBorders:
+		return set(uvBorders)
+
+	pinnit = set()
+	for face, uvFace in zip(faces, uvFaces):
+		for i in range(len(face)):
+			f = face[i]
+			pf = face[i-1]
+
+			uv = uvFace[i]
+			puv = uvFace[i-1]
+
+			if not(f in borders and pf in borders):
+				if uv in uvBorders and puv in uvBorders:
+					pinnit.add(puv)
+					pinnit.add(uv)
+
+	return uvBorders & pinnit
+
+def collapse(faces, verts, uvFaces, uvs):
+	""" Take a mesh representation with unused vertex indices and collapse it """
+	vset = sorted(list(set(chain.from_iterable(faces))))
+	nVerts = verts[vset]
+	vDict = {v: i for i, v in enumerate(vset)}
+	nFaces = [[vDict[f] for f in face] for face in faces]
+
+	if uvFaces is not None:
+		uvset = sorted(list(set(chain.from_iterable(uvFaces))))
+		nUVs = uvs[uvset]
+		uvDict = {v: i for i, v in enumerate(uvset)}
+		nUVFaces = [[uvDict[f] for f in face] for face in uvFaces]
+	else:
+		nUVs = None
+		nUVFaces = None
+
+	return nFaces, nVerts, nUVFaces, nUVs
+
+def getCenters(faces, hints=None, pBar=None):
+	"""
+	Given a set of faces, find the face-center vertices from the subdivision
+	Arguments:
+		faces ([[vIdx ...], ...]): The subdivided face structure
+		hints (None/list/set): An list or set containing vertex indices that
+			were part of the original un-subdivided mesh.
+			If not provided, it will auto-detect based on topology relative to the border
+			If there are no borders, it will pick an arbitrary (but not random) star point
+	"""
+	if pBar is not None:
+		pBar.setLabelText("Crawling Edges")
+		pBar.show()
+		QApplication.processEvents()
+
+	eNeigh = buildEdgeDict(faces)
+	if hints is None:
+		borders = getBorders(faces)
+		hints = buildUnsubdivideHints(faces, eNeigh, borders, pBar=None) # purposely no PBar
+	centerDel, fail = getFaceCenterDel(faces, eNeigh, hints, pBar=pBar)
+	assert not fail, "Could not detect subdivided topology with the provided hints"
+
+	if pBar is not None:
+		pBar.close()
+
+	return centerDel
+
+def unSubdivide(faces, verts, uvFaces, uvs, hints=None, repositionVerts=True, pinBorders=False, pBar=None):
+	"""
+	Given a mesh representation (faces and vertices) remove the edges added
+	by a subdivision, and optionally reposition the verts
+
+	Arguments:
+		faces ([[vIdx ...], ...]): The subdivided face structure
+		verts (np.array): The subdivided vertex positions
+		uvFaces ([[vIdx ...], ...]): The subdivided uv-face structure
+		uvs (np.array): The subdivided vertex positions
+
+		hints (None/list/set): An list or set containing vertex indices that
+			were part of the original un-subdivided mesh.
+			If not provided, it will auto-detect based on topology relative to the border
+			If there are no borders, it will pick an arbitrary (but not random) star point
+		repositionVerts (bool): Whether or not to calculate the original vert positions
+
+	Returns:
+		[[vIdx ...], ...]: The un-subdivided face structure
+		np.array: The un-subdivided vertex positions
+		[[vIdx ...], ...] or None: The un-subdivided uv-face structure if it exists
+		np.array or None: The un-subdivided uvs if they exist
+	"""
+	if pBar is not None:
+		pBar.show()
+		pBar.setLabelText("Finding Neighbors")
+		QApplication.processEvents()
+
+	eNeigh = buildEdgeDict(faces)
+
+	if hints is None:
+		if pBar is not None:
+			pBar.show()
+			pBar.setLabelText("Getting Hints")
+			QApplication.processEvents()
+		borders = getBorders(faces)
+		hints = buildUnsubdivideHints(faces, eNeigh, borders, pBar=None) # Purposely no PBar
+
+	if pBar is not None:
+		pBar.setLabelText("Crawling Edges")
+		QApplication.processEvents()
+	centerDel, fail = getFaceCenterDel(faces, eNeigh, hints, pBar=pBar)
+	assert not fail, "Could not detect subdivided topology with the provided hints"
+
+	if pBar is not None:
+		pBar.setLabelText("Deleting Edges")
+		QApplication.processEvents()
+	uFaces, uUVFaces, dWings, uvDWings = deleteCenters(faces, uvFaces, centerDel, pBar=pBar)
+
+	uVerts = verts
+	uUVs = uvs
+	if repositionVerts:
+		# Handle the verts
+		if pBar is not None:
+			pBar.setLabelText("Building Correspondences")
+			QApplication.processEvents()
+		neighDict, uNeighDict, edgeDict, uEdgeDict, borders = buildLayeredNeighborDicts(faces, uFaces, dWings)
+		pinned = set(borders) if pinBorders else []
+		if pBar is not None:
+			pBar.setLabelText("Fixing Vert Positions")
+			QApplication.processEvents()
+		uVerts = fixVerts(faces, uFaces, verts, neighDict, uNeighDict, edgeDict, uEdgeDict, borders, pinned, pBar=pBar)
+
+		# Handle the UVs
+		if uvFaces is not None:
+			uvNeighDict, uUVNeighDict, uvEdgeDict, uvUEdgeDict, uvBorders = buildLayeredNeighborDicts(uvFaces, uUVFaces, uvDWings)
+			uvPinned = getUVPins(faces, borders, uvFaces, uvBorders, pinBorders)
+			if pBar is not None:
+				pBar.setLabelText("Fixing UV Positions")
+				QApplication.processEvents()
+			uUVs = fixVerts(uvFaces, uUVFaces, uvs, uvNeighDict, uUVNeighDict, uvEdgeDict, uvUEdgeDict, uvBorders, uvPinned, pBar=pBar)
+
+	rFaces, rVerts, rUVFaces, rUVs = collapse(uFaces, uVerts, uUVFaces, uUVs)
+
+	if pBar is not None:
+		pBar.close()
+
+	return rFaces, rVerts, rUVFaces, rUVs
+
+
+
+####################################################################
+#                  Handle .smpx files here                         #
+####################################################################
+
+# TODO: In the future, allow for shape repositioning instead of just deletion
+
+def _ussmpx(faces, verts, uvFaces, uvs, pBar=None):
+	if pBar is not None:
+		pBar.show()
+		pBar.setLabelText("Finding Neighbors")
+		QApplication.processEvents()
+	else:
+		print "Finding Neighbors"
+
+	eNeigh = buildEdgeDict(faces)
+
+	if pBar is not None:
+		pBar.show()
+		pBar.setLabelText("Getting Hints")
+		QApplication.processEvents()
+	else:
+		print "Getting Hints"
+
+	borders = getBorders(faces)
+	hints = buildUnsubdivideHints(faces, eNeigh, borders, pBar=None) # Purposely no PBar
+
+	if pBar is not None:
+		pBar.setLabelText("Crawling Edges")
+		QApplication.processEvents()
+	else:
+		print "Crawling Edges"
+
+	centerDel, fail = getFaceCenterDel(faces, eNeigh, hints, pBar=pBar)
+	assert not fail, "Could not detect subdivided topology with the provided hints"
+
+	if pBar is not None:
+		pBar.setLabelText("Deleting Edges")
+		QApplication.processEvents()
+	else:
+		print "Deleting Edges"
+	uFaces, uUVFaces, dWings, uvDWings = deleteCenters(faces, uvFaces, centerDel, pBar=pBar)
+
+	uVerts = verts
+	uUVs = uvs
+	rFaces, rVerts, rUVFaces, rUVs = collapse(uFaces, uVerts, uUVFaces, uUVs)
+
+	if pBar is not None:
+		pBar.close()
+
+	return rFaces, rVerts, rUVFaces, rUVs
+
+def _openSmpx(inPath):
 	iarch = IArchive(str(inPath)) # because alembic hates unicode
 	top = iarch.getTop()
 	ixfo = IXform(top, top.children[0].getName())
-
 	iprops = ixfo.getSchema().getUserProperties()
 	iprop = iprops.getProperty("simplex")
 	jsString = iprop.getValue()
+	imesh = IPolyMesh(ixfo, ixfo.children[0].getName())
+	return iarch, imesh, jsString, ixfo.getName(), imesh.getName()
 
+def _applyShapePrefix(shapePrefix, jsString):
 	if shapePrefix is not None:
 		d = json.loads(jsString)
 		if d['encodingVersion'] > 1:
@@ -261,28 +836,15 @@ def exportUnsub(inPath, outPath, newFaces, kept, shapePrefix=None, pBar=None):
 		else:
 			d['shapes'] = [shapePrefix + i for i in d['shapes']]
 		jsString = json.dumps(d)
+	return jsString
 
-	imesh = IPolyMesh(ixfo, ixfo.children[0].getName())
-
-	verts = getSampleArray(imesh)
-	verts = verts[:, kept]
-
-	indices = []
-	counts = []
-	for f in newFaces:
-		indices.extend(f)
-		counts.append(len(f))
-
-	abcCounts = mkArray(IntArray, counts)
-	abcIndices = mkArray(IntArray, indices)
-
-	# `False` for HDF5 `True` for Ogawa
-	oarch = OArchive(str(outPath), False)
-	oxfo = OXform(oarch.getTop(), ixfo.getName())
+def _exportUnsub(outPath, xfoName, meshName, jsString, faces, verts, uvFaces, uvs, pBar=None):
+	oarch = OArchive(str(outPath), False) # False for HDF5
+	oxfo = OXform(oarch.getTop(), xfoName)
 	oprops = oxfo.getSchema().getUserProperties()
 	oprop = OStringProperty(oprops, "simplex")
 	oprop.setValue(str(jsString))
-	omesh = OPolyMesh(oxfo, imesh.getName())
+	omesh = OPolyMesh(oxfo, meshName)
 	osch = omesh.getSchema()
 
 	if pBar is not None:
@@ -291,48 +853,38 @@ def exportUnsub(inPath, outPath, newFaces, kept, shapePrefix=None, pBar=None):
 		pBar.setLabelText("Exporting Unsubdivided Shapes")
 		QApplication.processEvents()
 
+	abcIndices = mkSampleIntArray(chain.from_iterable(faces))
+	abcCounts = mkSampleIntArray(map(len, faces))
+
+	kwargs = {}
+	if uvs:
+		# Alembic doesn't use None as the placeholder for un-passed kwargs
+		# So I don't have to deal with that, I only set the kwarg dict if the uvs exist
+		uvidx = None if uvFaces is None else chain.from_iterable(uvFaces)
+		uvSample = mkUvSample(uvs, uvidx)
+		kwargs['iUVs'] = uvSample
+
 	for i, v in enumerate(verts):
 		if pBar is not None:
 			pBar.setValue(i)
 			QApplication.processEvents()
 		else:
 			print "Exporting Unsubdivided Shape {0: <4}\r".format(i+1),
-		sample = OPolyMeshSchemaSample(mkSampleVertexPoints(v), abcIndices, abcCounts)
+		sample = OPolyMeshSchemaSample(mkSampleVertexPoints(v), abcIndices, abcCounts, **kwargs)
 		osch.set(sample)
+
 	if pBar is None:
 		print "Exporting Unsubdivided Shape {0: <4}".format(len(verts))
 
-
-
-
-
 def unsubdivideSimplex(inPath, outPath, shapePrefix=None, pBar=None):
-	''' Unsubdivide a simplex file '''
-	print "Loading"
-	verts, faces = parseAbc(inPath)
+	iarch, imesh, jsString, xfoName, meshName = _openSmpx(inPath)
+	jsString = _applyShapePrefix(shapePrefix, jsString)
 
-	print "Parsing"
-	adj = buildEdgeAdjacency(faces)
-	diag = buildDiagonalAdjacency(faces)
-	bound = findBoundaryVerts(adj, diag)
-	islands = partitionIslands(adj, len(verts))
-	hints = [buildHints(isle, bound, adj) for isle in islands]
+	verts = getSampleArray(imesh)
+	faces = getMeshFaces(imesh)
+	uvFaces = getUvFaces(imesh)
+	uvs = getUvArray(imesh)
 
-	print "Unsubdividing"
-	originals, edges, centers = partitionVerts(hints, adj, diag)
-	delFaces = buildNewFaces(faces, centers, diag)
-	newFaces, kept = squashFaces(delFaces)
-
-	print "Exporting"
-	exportUnsub(inPath, outPath, newFaces, kept, shapePrefix=shapePrefix, pBar=pBar)
-
-	print "Done"
-
-if __name__ == '__main__':
-	_inPath = r'D:\Users\tyler\Desktop\JawOnly.smpx'
-	_outPath = r'D:\Users\tyler\Desktop\JawOnlyUnsub.smpx'
-
-	unsubdivideSimplex(_inPath, _outPath)
-
-
+	uFaces, verts, uUVFaces, uUVs = _ussmpx(faces, verts, uvFaces, uvs, pBar=pBar)
+	_exportUnsub(outPath, xfoName, meshName, jsString, faces, verts, uvFaces, uvs, pBar=pBar)
 

--- a/scripts/SimplexUI/commands/uvTransfer.py
+++ b/scripts/SimplexUI/commands/uvTransfer.py
@@ -1,0 +1,696 @@
+# pylint: disable=invalid-name
+from __future__ import division
+import numpy as np
+
+INF = float('inf')
+EPS = 1e-7
+
+
+########################
+# Mean Value Coords
+########################
+
+def _lerp(idx, corners, p):
+	# If I'm here, I know that p lies on the line
+	# between the corners at idx and idx+1.
+	# Return the lerp value
+	ip = (idx+1) % len(corners)
+	c1 = corners[idx]
+	c2 = corners[ip]
+	base = c1 - c2
+	proj = np.dot(p-c2, base)
+	b = proj / (base**2).sum()
+	ret = np.zeros(len(corners))
+	ret[idx] = b
+	ret[ip] = 1.0 - b
+	return ret
+
+def mvc(corners, p, tol=EPS):
+	""" Get the Mean Value Coordinates of a point p in the polygon defined by corners
+	Arguments:
+		corners(list): The ordered corner points of the polygon
+		p(np.array): The point to get the coordinates for
+		tol(float): The snap tolerance around the vertices and edges
+
+	Returns:
+		weights(list): The normalized list of barycentric weights
+			for this point in the polygon
+	"""
+	spokes = corners - p
+	spokeLens = (spokes*spokes).sum(axis=1)
+
+	# Check if p is on top of a vertex
+	for i, v in enumerate(spokeLens):
+		if v < tol:
+			bary = np.zeros(len(corners))
+			bary[i] = 1.0
+			return bary
+
+	rspokes = np.roll(spokes, -1, axis=0)
+	areas = np.cross(spokes, rspokes) * 0.5
+	dots = (spokes * rspokes).sum(axis=1)
+
+	for i, v in enumerate(areas):
+		if v < tol and dots[i] < 0.0:
+			return _lerp(i, corners, p)
+
+	spokeLens = spokeLens ** 0.5
+	rspokeLens = np.roll(spokeLens, -1)
+	t = areas / (spokeLens*rspokeLens + dots)
+	rawWeights = (np.roll(t, 1) + t) / spokeLens
+	return rawWeights / sum(rawWeights)
+
+def mmvc(rawFaces, points, samples, uvToFace, tol=EPS):
+	""" Multi-MeanValueCoords
+	Get the MVC's of many points over many faces using numpy
+
+	Arguments:
+		rawFaces (list): List of lists of face indices
+		points (np.array): List of vertices for those faces
+		samples (np.array): List of points to sample
+		uvIdxs (dict): A dictionary of uvIndex to faceIndex
+		tol (float): The tolerance for edge and point overlap
+
+	Returns:
+		dict: {fc: (wh, barys)} A dictionary of face counts to
+			a tuple containing the indices of the face indices
+			checked, and the barycentric coords
+	"""
+	uvIdxs, faceIdxs = sorted(zip(*uvToFace.items()))
+	uvIdxs = np.array(uvIdxs)
+	faces = [rawFaces[fi] for fi in faceIdxs]
+	faceLens = np.array([len(i) for i in faces])
+	fcs = np.unique(faceLens)
+
+	out = {}
+	for fc in fcs:
+		wh = np.where(faceLens == fc)[0]
+		cIdxs = np.array([faces[i] for i in wh])
+		barys = np.zeros(cIdxs.shape)
+		qIdxs = uvIdxs[wh]
+		out[fc] = (qIdxs, barys) # edit barys in-place
+
+		# cornerses is a [f, fc, 2] array
+		# where f is num of faces, fc is verts per face, and 2 because uv is 2d
+		# pts is [f, 2] array where f is num faces
+		cornerses = points[cIdxs]
+		pts = samples[qIdxs]
+
+		# Get the "spokes" from the query point to the face corners
+		# and get their squared lengths
+		spokes = cornerses - pts[:, None, :]
+		spokeLens2 = (spokes * spokes).sum(axis=-1)
+
+		# Handle any samples that are directly on top of a corner
+		# (where the spoke length is zero)
+		zeros = np.any(spokeLens2 < tol, axis=1)
+		onPoint = np.where(zeros)
+		offPoint = np.where(~zeros)
+		if onPoint[0].size:
+			pIdxs = spokeLens2[onPoint].argmin(axis=1)
+			barys[onPoint, pIdxs] = 1.0
+
+		if not offPoint[0].size:
+			continue
+
+		# Ignore those points that have already been computed
+		idxs = offPoint[0]
+		spokes = spokes[offPoint]
+		spokeLens2 = spokeLens2[offPoint]
+
+		# Get the signed area of each triangle created by the spokes
+		# and the dot product for the angle between each
+		rspokes = np.roll(spokes, -1, axis=1)
+		areas = np.cross(spokes, rspokes) * 0.5
+		dots = (spokes * rspokes).sum(axis=-1)
+
+		# Handle any samples that are directly on an edge between
+		# two corners. (Where the triangle area is 0, and the
+		# dot product is negative)
+		aareas = abs(areas)
+		zeros = aareas < tol
+		ndots = dots < 0.0
+		zn = zeros & ndots
+		toLerp = np.any(zn, axis=-1)
+		onEdge = np.where(toLerp)
+		offEdge = np.where(~toLerp)
+		if onEdge[0].size:
+			subIdx = idxs[onEdge]
+			pIdxs = zn[onEdge].argmax(axis=-1)
+			xIdxs = (pIdxs + 1) % fc
+
+			ppIdxs = cIdxs[subIdx, pIdxs]
+			xpIdxs = cIdxs[subIdx, xIdxs]
+
+			cp = pts[subIdx]
+			pp = points[ppIdxs]
+			xp = points[xpIdxs]
+
+			bases = pp - xp
+			diff = cp - xp
+			proj = (bases * diff).sum(axis=-1)
+			b = proj / (bases**2).sum(axis=1)
+			mb = 1.0 - b
+			barys[subIdx, pIdxs] = b
+			barys[subIdx, xIdxs] = mb
+
+		if not offEdge[0].size:
+			continue
+
+		idxs = idxs[offEdge]
+		dots = dots[offEdge]
+		areas = areas[offEdge]
+		spokeLens2 = spokeLens2[offEdge]
+		spokeLens = spokeLens2 ** 0.5
+		rspokeLens = np.roll(spokeLens, -1, axis=1)
+
+		t = areas / (spokeLens*rspokeLens + dots)
+		rawWeights = (np.roll(t, -1, axis=1) + t) / spokeLens
+		b = rawWeights / rawWeights.sum(axis=1)[..., None]
+		barys[idxs] = b
+
+	ret = {}
+	for qIdxs, barys in out.itervalues():
+		for qi, b in zip(qIdxs, barys):
+			ret[qi] = (uvToFace[qi], b)
+
+	return ret
+
+
+########################
+# Sweep algorithm
+########################
+
+def triArea(a, b, c):
+	''' Use the cross-ish-product to find the area of the triangle
+	Depending on the winding, the area could be positive or negative
+	'''
+	return (a[0] * (c[1] - b[1]) + b[0] * (a[1] - c[1]) + c[0] * (b[1] - a[1])) / 2.0
+
+def pointInTri(p, a, b, c, tol=EPS):
+	''' Check that the point is inside the triangle '''
+	area = abs(triArea(a, b, c))
+	chis = abs(triArea(p, b, c)) + abs(triArea(a, p, c)) + abs(triArea(a, b, p))
+	return abs(area - chis) < tol
+
+def sweep(qPoints, uvs, tris, pBar=None):
+	''' Get what triangle each query point is inside
+
+	Runs a sweep-line algorithm to check for points in triangles.
+	Imagine a uv layout, and a bunch of points on the layout.
+	Now imagine a vertical line sweeping across the uv plane from the left
+	to the right. The sorted u-values of certain properties then handled
+	one-by-one.
+
+	The algorithm keeps track of what triangles the vertical line is currently intersecting.
+		This is done by storing the min and max u-values for each triangle.
+		If the u-value encountered is the min for a tri, that tri is added to the list
+		If the u-value encountered is the max for a tri, that tri is removed from the list
+	Then, each time a query point is encountered, it only has to check the intersection list
+
+	Arguments:
+		qPoints(np.array): An Nx2 array of uv points to query
+		uvs(np.array): An Mx2 array of uvs that make up the triangulated plane
+		tris(np.array): A Wx3 array of uv indexes, each row being 3 uv indexes that form a tri
+		pBar(QProgressDialog): A progress bar instance, or None.
+
+	Returns:
+		out(dict): A dictionary of out[pointIndex] = triIndex
+		missing(set): A set containing the pointIndexes that weren't found in a triangle
+	'''
+	tpts = uvs[tris]  # [tIdx, abc, xy]
+
+	allmxs, allmns = tpts.max(axis=1), tpts.min(axis=1)
+	ymxs, ymns = allmxs[:, 1], allmns[:, 1]
+	mxs, mns = allmxs[:, 0], allmns[:, 0]
+	qpx = qPoints[:, 0]
+	qpSIdxs, mxSIdxs, mnSIdxs = np.argsort(qpx), np.argsort(mxs), np.argsort(mns)
+	qpSIdx, mxSIdx, mnSIdx = 0, 0, 0
+	qpIdx, mxIdx, mnIdx = qpSIdxs[qpSIdx], mxSIdxs[mxSIdx], mnSIdxs[mnSIdx]
+	qp, mx, mn = qpx[qpIdx], mxs[mxIdx], mns[mnIdx]
+
+	out = {}
+	missing = set()
+
+	if pBar is not None:
+		pBar.setValue(0)
+		allVals = len(qpSIdxs) + len(mxSIdxs) + len(mnSIdxs)
+		pBar.setRange(0, allVals)
+		pBar.setLabelText("Sweeping ...")
+		from Qt.QtWidgets import QApplication
+		QApplication.processEvents()
+
+	# skip any triangles to the left of the first query point
+	# The algorithm will stop once we hit the last query point
+	skip = [qp > m for m in mxs]
+	activeTris = [False for _ in mxs] # For fast membership testing
+	atSet = set() # For fast iteration
+
+	while True:
+		if pBar is not None:
+			cVal = qpSIdx + mnSIdx + mxSIdx
+			if cVal % 1283 == 0: # Just a random prime
+				pBar.setValue(cVal)
+				pBar.setLabelText("Sweeping ...\n{0}/{1}".format(cVal, allVals))
+				QApplication.processEvents()
+				if pBar.wasCanceled():
+					raise RuntimeError("Cancelled!")
+
+		if mn <= mx and mn <= qp:
+			# Always add triangles first if possible
+			aTriIdx = mnSIdxs[mnSIdx]
+			if not activeTris[aTriIdx] and not skip[aTriIdx]:
+				activeTris[aTriIdx] = True
+				atSet.add(aTriIdx)
+
+			mnSIdx += 1
+			if mnSIdx != len(mnSIdxs):
+				mnIdx = mnSIdxs[mnSIdx]
+				mn = mns[mnIdx]
+			else:
+				mn = mxs[mxSIdxs[-1]] + 1
+
+		elif qp <= mx:
+			# Check query points between adding and removing
+			qPoint = qPoints[qpIdx]
+			yv = qPoint[1]
+			# A linear search is faster than more complex collections here
+			for t in atSet:
+				if ymns[t] <= yv <= ymxs[t]:
+					a, b, c = uvs[tris[t]]
+					if pointInTri(qPoint, a, b, c):
+						out[qpIdx] = t
+						break
+			else:
+				missing.add(qpIdx)
+
+			qpSIdx += 1
+			if qpSIdx == len(qpSIdxs):
+				break
+			qpIdx = qpSIdxs[qpSIdx]
+			qp = qpx[qpIdx]
+
+		else:
+			# always remove triangles last
+			aTriIdx = mxSIdxs[mxSIdx]
+			if activeTris[aTriIdx] and not skip[aTriIdx]:
+				activeTris[aTriIdx] = False
+				atSet.remove(aTriIdx)
+
+			mxSIdx += 1
+			if mxSIdx != len(mxSIdxs):
+				mxIdx = mxSIdxs[mxSIdx]
+				mx = mxs[mxIdx]
+
+	return out, missing
+
+
+########################
+# Triangulation
+########################
+
+def inBox(point, mxs, mns):
+	''' Check if a point is inside the bounding box '''
+	return np.all(point <= mxs) and np.all(point >= mns)
+
+def _isEar(a, b, c, polygon, tol=EPS):
+	''' Check if the points a,b,c of the polygon could be their own triangle '''
+	signedArea = triArea(a, b, c)
+
+	# Check that the triange is wound the correct way.
+	if signedArea > 0:
+		return False
+
+	# Check that the triangle has non-zero area
+	# we already know the area is negative from above
+	if -signedArea < tol:
+		return False
+
+	# Check that none of the other points in the polygon are contained in triangle
+	for p in polygon:
+		if p not in (a, b, c):
+			if pointInTri(p, a, b, c, tol=tol):
+				return False
+	return True
+
+def earclip(idxs, verts):
+	''' Simple earclipping algorithm
+	For a polygon with n points it will return n-2 triangles.
+	'''
+	earVerts = []
+	tris = []
+	idxs = list(idxs)
+	polygon = [tuple(verts[i]) for i in idxs]
+
+	numPts = len(polygon)
+	for i in range(numPts):
+		prev = polygon[i - 2]
+		cur = polygon[i - 1]
+		nxt = polygon[i]
+		if _isEar(prev, cur, nxt, polygon):
+			earVerts.append(cur)
+
+	while earVerts and numPts >= 3:
+		ear = earVerts.pop()
+		i = polygon.index(ear)
+		pi, ni = i-1, (i+1) % numPts
+
+		prevPt = polygon[pi]
+		nxtPt = polygon[ni]
+		tris.append((idxs[pi], idxs[i], idxs[ni]))
+
+		polygon.pop(i)
+		idxs.pop(i)
+		numPts -= 1
+		if numPts > 3:
+			prePrePt = polygon[i - 2]
+			nxtNxtPt = polygon[(i + 1) % numPts]
+
+			groups = [
+				(prePrePt, prevPt, nxtPt, polygon),
+				(prevPt, nxtPt, nxtNxtPt, polygon)
+			]
+
+			for group in groups:
+				p = group[1]
+				if _isEar(*group):
+					if p not in earVerts:
+						earVerts.append(p)
+				elif p in earVerts:
+					earVerts.remove(p)
+	return tris
+
+def triangulateUVs(faces, uvs):
+	''' Take a set of uvFaces and uv points, and triangulate it
+
+	Arguments:
+		faces(list): A list of lists of uv indexes
+		uvs(np.array): A Nx2 array of uv positions
+
+	Returns:
+		tris(np.array): A Nx3 array of uv indexes making triangles
+		triMap(list): A list where the index is the triangle index,
+			and the value is the face index
+		borderFaceMap(dict): A dictionary of border edge pairs to border faces
+	'''
+	uvs = np.array(uvs)
+	triMap = []
+	tris = []
+	borderFaceMap = {}
+	# Build the naiive triangulation
+	# And get the borders while I'm looping
+	for f, face in enumerate(faces):
+		for i in range(2, len(face)):
+			triMap.append(f)
+			tris.append((face[0], face[i-1], face[i]))
+
+		for i in range(len(face)):
+			ep = (face[i-1], face[i])
+			if ep[0] > ep[1]:
+				ep = (ep[1], ep[0])
+			if ep in borderFaceMap:
+				borderFaceMap.pop(ep)
+			else:
+				borderFaceMap[ep] = f
+
+	tris = np.array(tris)
+	tuvs = uvs[tris]
+
+	# Get the area using a 2d-pseudo-cross-product
+	a = tuvs[:, 0] - tuvs[:, 1]
+	b = tuvs[:, 2] - tuvs[:, 1]
+	signedAreas = (a[:, 0]*b[:, 1] - a[:, 1]*b[:, 0])
+
+	# Things with negative area are wound backwards in this case
+	negArea = np.where(signedAreas < 0)
+
+	# Do we need to retriangulate any of the polys
+	retri = sorted(set(triMap[i] for i in negArea[0]))
+	if retri:
+		tris = tris.tolist()
+		tmpFaceMap = {}
+		# tmpFaceMap is only good while we re-triangulate
+		# it has to be re-built after
+		for t, f in enumerate(triMap):
+			tmpFaceMap.setdefault(f, []).append(t)
+
+		for f in retri[::-1]:
+			good = earclip(faces[f], uvs)
+			tidxs = tmpFaceMap[f]
+			tris[tidxs[0]: tidxs[-1]+1] = good
+			triMap[tidxs[0]: tidxs[-1]+1] = [f] * len(good)
+		tris = np.array(tris)
+
+	return tris, triMap, borderFaceMap
+
+
+########################
+# UV Transferring
+########################
+
+MISSING = {}
+
+def cooSparseMul(M, v):
+	''' Multply the sparse matrix by the vector '''
+	# Using scipy is at least 2x faster than the
+	# pure numpy implementation. But even that
+	# is about 5x faster than using a dense matrix
+	try:
+		from scipy import sparse
+	except ImportError:
+		# No scipy, use numpy
+		row, col, val, shape = M
+		v = v.swapaxes(0, -2)
+		vshape = val.shape + tuple([1]*(len(v)-1))
+		val = val.reshape(vshape)
+		out = np.zeros(shape[:1] + v.shape[1:])
+		np.add.at(out, row, val*v[col])
+		out = out.swapaxes(0, -2)
+	else:
+		row, col, val, shape = M
+		spM = sparse.coo_matrix((val, (row, col)), shape=shape)
+		spM = sparse.csr_matrix(spM)
+		if len(v.shape) == 3:
+			out = np.array([spM.dot(frm) for frm in v])
+		else:
+			out = spM.dot(v)
+	return out
+
+def getUvCorrelation(samples, points, faces, tol=0.0001, handleMissing=True, pBar=None):
+	''' Get the per-face correlation of the sample points in uv space.
+
+	Returns:
+		dict[sampleIdx] = (faceIdx, [cornerWeights])
+	'''
+	tris, triMap, borderMap = triangulateUVs(faces, points)
+	swept, missing = sweep(samples, points, tris, pBar=pBar)
+	uvToFace = {uvI: triMap[tI] for uvI, tI in swept.iteritems()}
+	#import __main__
+	#__main__.__dict__.update(locals())
+	#raise RuntimeError("STOPPIT")
+	if pBar is not None:
+		pBar.setValue(0)
+		pBar.setRange(0, len(uvToFace))
+		pBar.setLabelText("Calculate Mean Value Coords")
+		from Qt.QtWidgets import QApplication
+		QApplication.processEvents()
+
+	#mvcDict = {}
+	#for i, (uvIdx, faceIdx) in enumerate(uvToFace.iteritems()):
+		#if pBar is not None:
+			#pBar.setValue(i)
+			#pBar.setLabelText("Calculate Mean Value Coords\n{0}/{1}".format(i, len(uvToFace)))
+			#QApplication.processEvents()
+		#uv = samples[uvIdx]
+		#corners = points[faces[faceIdx]]
+		#bary = mvc(corners, uv)
+		#mvcDict[uvIdx] = (faceIdx, bary)
+
+	mvcDict = mmvc(faces, points, samples, uvToFace)
+
+	# find the closest border
+	# Just use a brute-force search
+	# ... for now
+
+	if missing and handleMissing:
+		if pBar is not None:
+			pBar.setValue(0)
+			pBar.setLabelText("Handle Missing")
+			QApplication.processEvents()
+		tol = tol ** 2
+		bk = borderMap.keys()
+		borders = np.array(bk)
+		bStarts = points[borders[:, 0]]
+		bEnds = points[borders[:, 1]]
+
+		bDiff = bEnds - bStarts
+		bLens2 = (bDiff * bDiff).sum(axis=1)
+		for mIdx in missing:
+			mp = samples[mIdx]
+			dSquared = _mpCheck(bStarts, bDiff, bLens2, mp)
+			minIdx = np.argmin(dSquared)
+			if dSquared[mIdx] < tol:
+				faceIdx = borderMap[bk[minIdx]]
+				corners = points[faces[faceIdx]]
+				bary = mvc(corners, mp)
+				mvcDict[mIdx] = (faceIdx, bary)
+
+	return mvcDict
+
+def _mpCheck(a, d, dr2, pt):
+	''' Point to Multi-segment squared distance
+	Uses pre-computed values '''
+	lerp = ((pt - a) * d).sum(axis=1) / dr2
+	lerp = np.clip(lerp, 0, 1)
+	xy = (lerp[:, None] * d) + a
+	_dxy = xy - pt
+	return (_dxy * _dxy).sum(axis=1)
+
+def getVertCorrelation(sUvFaces, sUvs, tVertFaces, tUvFaces, tUvs, tol=0.0001, pBar=None):
+	''' Build the vertex position correlation between two meshes
+	by looking through UV-space. Handle combining multiple uvs
+	per vertex, and having samples that live outside the coverage
+
+	Arguments:
+		sUvFaces(list): List of uv indices per face for the source
+		sUvs(np.array): Array of uv positions for the source
+		tVertFaces(list): List of vert indices per face for the target
+		tUvFaces(list): List of uv indices per face for the target
+		tUvs(np.array): Array of uv positions for the target
+
+	Returns:
+		dict[sampleIdx] = (faceIdx, [cornerWeights])
+	'''
+	childUvToVert = {}
+	cNumVerts = -1
+	for vF, uvF in zip(tVertFaces, tUvFaces):
+		for vIdx, uvIdx in zip(vF, uvF):
+			cNumVerts = max(cNumVerts, vIdx)
+			childUvToVert[uvIdx] = vIdx
+
+	mvcUvDict = getUvCorrelation(tUvs, sUvs, sUvFaces, tol=tol, pBar=pBar)
+
+	mvcVertDict = {}
+	for uvIdx in range(len(tUvs)):
+		if uvIdx not in mvcUvDict:
+			continue
+		mvcVertDict.setdefault(childUvToVert[uvIdx], []).append(mvcUvDict[uvIdx])
+
+	missing = set(range(cNumVerts)) - mvcVertDict.viewkeys()
+	if missing:
+		import time
+		v = time.time()
+		print "Missing correspondences found. Stored in uvTransfer.MISSING[{0}]".format(v)
+		MISSING[v] = missing
+
+	return mvcVertDict
+
+def applyTransfer(parVerts, parFaces, correlation, outputSize):
+	'''
+	Given a vertex corelation, a driver, and driven points,
+	Apply the driver deformation to the driven. This could be
+	for one frame, or many frames
+	'''
+	if len(parVerts.shape) == 2:
+		parVerts = parVerts[None, ...]
+
+	rows, cols, vals = [], [], []
+	for cVertIdx, corrPoss in correlation.iteritems():
+		if len(corrPoss) == 1:
+			pFaceIdx, bary = corrPoss[0]
+		else:
+			# pick the one with the highest sum-of-squares
+			x = [sum(bary * bary) for _, bary in corrPoss]
+			idx = x.index(max(x))
+			pFaceIdx, bary = corrPoss[idx]
+
+		rows.extend([cVertIdx] * len(bary))
+		vals.extend(bary)
+		cols.extend(parFaces[pFaceIdx])
+	M = np.array(rows), np.array(cols), np.array(vals), (outputSize, parVerts.shape[-2])
+	out = cooSparseMul(M, parVerts)
+	return out
+
+def uvTransfer(srcFaces, srcUvFaces, srcVerts, srcUvs, tarFaces, tarUvFaces, tarVerts, tarUvs, tol=0.0001, pBar=None):
+	''' A helper function that transfers pre-loaded data.
+	The source data will be transferred onto the tar data
+
+	Arguments:
+		srcFaces(list): A face list of the source verts
+		srcUvFaces(list): A face list of the source uvs
+		srcUvs(np.array): The source uvs
+		tarFaces(list): A face list of the target verts
+		tarUvFaces(list): A face list of the target uvs
+		tarUvs(np.array): The target uvs
+
+	Returns:
+		out(np.array): The target vert positions
+
+	'''
+	corr = getVertCorrelation(srcUvFaces, srcUvs, tarFaces, tarUvFaces, tarUvs, tol=tol, pBar=pBar)
+	if pBar is not None:
+		pBar.setValue(0)
+		pBar.setLabelText("Apply Transfer")
+		from Qt.QtWidgets import QApplication
+		QApplication.processEvents()
+
+	return applyTransfer(srcVerts, srcFaces, corr, len(tarVerts))
+
+def uvTransferLoad(srcPath, tarPath, srcUvSet='default', tarUvSet='default', tol=0.0001, pBar=None):
+	''' Transfer the shape from the source to the target through uv space
+	Return the data needed to write out the result
+
+	Arguments:
+		srcPath(str): The filepath to the source object
+		tarPath(str): The filepath to the target object
+
+	Returns:
+		tarVerts(np.array): The target vertex positions
+		tarFaces(list): The target vertex faces
+		tarUvs(np.array): The target uvs
+		tarUvFaces(list): The target uv faces
+	'''
+	from blur3d.api.classes.mesh import Mesh
+	from blur3d.api.classes import abc
+	if srcPath.endswith('.abc') or srcPath.endswith('.smpx'):
+		src = Mesh.loadAbc(srcPath, ensureWinding=False)
+		srcVerts = abc.getSampleArray(abc.getMesh(srcPath))
+	elif srcPath.endswith('.obj'):
+		src = Mesh.loadObj(srcPath, ensureWinding=False)
+		srcVerts = np.array(src.vertArray)
+
+	if tarPath.endswith('.abc'):
+		tar = Mesh.loadAbc(tarPath, ensureWinding=False)
+	elif tarPath.endswith('.obj'):
+		tar = Mesh.loadObj(tarPath, ensureWinding=False)
+
+	srcFaces = src.faceVertArray
+	srcUvFaces = src.uvFaceMap[srcUvSet]
+	srcUvs = np.array(src.uvMap[srcUvSet])
+
+	tarFaces = tar.faceVertArray
+	tarUvFaces = tar.uvFaceMap[tarUvSet]
+	tarUvs = np.array(tar.uvMap[tarUvSet])
+	oldTarVerts = np.array(tar.vertArray)
+	tarVerts = uvTransfer(
+		srcFaces, srcUvFaces, srcVerts, srcUvs, tarFaces,
+		tarUvFaces, oldTarVerts, tarUvs, tol=tol, pBar=pBar
+	)
+
+	return tarVerts, tarFaces, tarUvs, tarUvFaces
+
+def uvTransferFiles(srcPath, tarPath, outAbcPath, srcUvSet='default', tarUvSet='default', tol=0.0001, pBar=None):
+	''' Transfer the shape from the source to the target through uv space
+	and write out the result
+
+	Arguments:
+		srcPath(str): The filepath to the source object
+		tarPath(str): The filepath to the target object
+		outAbcPath(str): The filepath for the result alembic file
+	'''
+	from blur3d.api.classes import abc
+	tarVerts, tarFaces, tarUvs, tarUvFaces = uvTransferLoad(
+		srcPath, tarPath, srcUvSet=srcUvSet, tarUvSet=tarUvSet, tol=tol, pBar=pBar
+	)
+	abc.buildAbc(outAbcPath, tarVerts, tarFaces, uvs=tarUvs, uvFaces=tarUvFaces)
+

--- a/scripts/SimplexUI/constants.py
+++ b/scripts/SimplexUI/constants.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-from SimplexUI.Qt.QtCore import Qt
+from .Qt.QtCore import Qt
 
 PRECISION = 4
 COLUMNCOUNT = 3

--- a/scripts/SimplexUI/dragFilter.py
+++ b/scripts/SimplexUI/dragFilter.py
@@ -65,9 +65,9 @@ Instance Options:
 		held down.  This option turns that off
 """
 
-from SimplexUI.Qt.QtCore import QObject, QPoint, Qt, QEvent, Signal
-from SimplexUI.Qt.QtWidgets import QApplication
-from SimplexUI.Qt.QtGui import QCursor, QMouseEvent
+from .Qt.QtCore import QObject, QPoint, Qt, QEvent, Signal
+from .Qt.QtWidgets import QApplication
+from .Qt.QtGui import QCursor, QMouseEvent
 
 class DragFilter(QObject):
 	DRAG_ENABLED = 0

--- a/scripts/SimplexUI/dummyInterface.py
+++ b/scripts/SimplexUI/dummyInterface.py
@@ -21,15 +21,15 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 """ A placeholder interface that takes arguments and does nothing with them """
 import json, copy
 from contextlib import contextmanager
-from SimplexUI.Qt import QtCore
-from SimplexUI.Qt.QtCore import Signal
+from .Qt import QtCore
+from .Qt.QtCore import Signal
 from functools import wraps
 try:
 	import numpy as np
 except ImportError:
 	np = None
-from SimplexUI.commands.alembicCommon import getSampleArray, mkSampleIntArray, getStaticMeshData, getUvArray, getUvSample, mkSampleVertexPoints
-from SimplexUI.Qt.QtWidgets import QApplication
+from .commands.alembicCommon import getSampleArray, mkSampleIntArray, getStaticMeshData, getUvArray, getUvSample, mkSampleVertexPoints
+from .Qt.QtWidgets import QApplication
 from alembic.AbcGeom import OPolyMeshSchemaSample, OV2fGeomParamSample, GeometryScope
 
 # UNDO STACK INTEGRATION
@@ -431,6 +431,15 @@ class DCC(object):
 		""" return the currently selected DCC objects """
 		# For maya, only return transform nodes
 		return [DummyNode("thing")]
+
+
+class SliderDispatch(QtCore.QObject):
+	valueChanged = Signal()
+	def __init__(self, node, parent=None):
+		super(SliderDispatch, self).__init__(parent)
+
+	def emitValueChanged(self, *args, **kwargs):
+		self.valueChanged.emit()
 
 
 class Dispatch(QtCore.QObject):

--- a/scripts/SimplexUI/falloffDialog.py
+++ b/scripts/SimplexUI/falloffDialog.py
@@ -21,14 +21,14 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 # This module imports QT from PyQt4, PySide or PySide2
 # Depending on what's available
 import re
-from SimplexUI.Qt import QtCompat
-from SimplexUI.Qt.QtCore import QSettings
-from SimplexUI.Qt.QtGui import QStandardItemModel
-from SimplexUI.Qt.QtWidgets import QInputDialog, QDataWidgetMapper, QMessageBox, QDialog
+from .Qt import QtCompat
+from .Qt.QtCore import QSettings
+from .Qt.QtGui import QStandardItemModel
+from .Qt.QtWidgets import QInputDialog, QDataWidgetMapper, QMessageBox, QDialog
 
-from SimplexUI.utils import getUiFile, getNextName
-from SimplexUI.interfaceItems import Falloff
-from SimplexUI.interfaceModel import FalloffDataModel
+from .utils import getUiFile, getNextName
+from .interfaceItems import Falloff
+from .interfaceModel import FalloffDataModel
 
 try:
 	# This module is unique to Blur Studio
@@ -96,8 +96,6 @@ class FalloffDialog(QDialog):
 
 	# Falloff Settings
 	def newFalloff(self):
-		if not self.simplex.falloffs:
-			return
 		foNames = [f.name for f in self.simplex.falloffs]
 		tempName = getNextName("NewFalloff", foNames)
 

--- a/scripts/SimplexUI/interfaceItems.py
+++ b/scripts/SimplexUI/interfaceItems.py
@@ -26,19 +26,15 @@ except ImportError:
 	np = None
 from alembic.Abc import OArchive, IArchive, OStringProperty
 from alembic.AbcGeom import OXform, OPolyMesh, IXform, IPolyMesh
-from SimplexUI.Qt.QtGui import QColor
-from SimplexUI.Qt.QtWidgets import QApplication
+from .Qt.QtGui import QColor
+from .Qt.QtWidgets import QApplication
 from utils import getNextName, nested, singleShot, caseSplit, makeUnique
 from contextlib import contextmanager
 from collections import OrderedDict
 from functools import wraps
 from interface import DCC, undoContext
 from dummyInterface import DCC as DummyDCC
-try:
-	# This module is unique to Blur Studio
-	import blurdev
-except ImportError:
-	blurdev = None
+from . import OGAWA
 
 
 # UNDO STACK SETUP
@@ -1925,9 +1921,11 @@ class TravPair(SimplexAccessor):
 
 	def treeData(self, column):
 		if column == 0:
-			return self.usage.upper()
+			return self.controller.name
 		elif column == 1:
 			return self.value
+		elif column == 2:
+			return self.usage.upper()
 		return None
 
 
@@ -2870,11 +2868,7 @@ class Simplex(object):
 		defDict = self.buildDefinition()
 		jsString = json.dumps(defDict)
 		path = str(path) # alembic does not like unicode filepaths
-		if blurdev is not None:
-			# Export as HDF5 if at blur
-			arch = OArchive(str(path), False)
-		else:
-			arch = OArchive(str(path))
+		arch = OArchive(str(path), OGAWA)
 
 		try:
 			par = OXform(arch.getTop(), str(self.name))

--- a/scripts/SimplexUI/interfaceItems.py
+++ b/scripts/SimplexUI/interfaceItems.py
@@ -2221,7 +2221,7 @@ class Group(SimplexAccessor):
 		''' Convenience method for creating a group '''
 		g = cls(name, simplex, groupType)
 		if things is not None:
-			g.add(things)
+			g.take(things)
 		return g
 
 	@classmethod
@@ -2279,20 +2279,6 @@ class Group(SimplexAccessor):
 				item.delete()
 
 	@stackable
-	def add(self, things): ### Moves Rows (Slider)
-		if self.groupType is None:
-			self.groupType = type(things[0])
-
-		if not all([isinstance(i, self.groupType) for i in things]):
-			raise ValueError("All items in this group must be of type: {}".format(self.groupType))
-
-		# do it this way instead of using set() to keep order
-		for thing in things:
-			if thing not in self.items:
-				self.items.append(thing)
-				thing.group = self
-
-	@stackable
 	def take(self, things):
 		if self.groupType is None:
 			self.groupType = type(things[0])
@@ -2302,7 +2288,8 @@ class Group(SimplexAccessor):
 
 		# do it this way instead of using set() to keep order
 		for thing in things:
-			thing.setGroup(self)
+			if thing not in self.items:
+				thing.setGroup(self)
 
 
 class Simplex(object):

--- a/scripts/SimplexUI/interfaceItems.py
+++ b/scripts/SimplexUI/interfaceItems.py
@@ -810,10 +810,11 @@ class ProgPair(SimplexAccessor):
 
 	@stackable
 	def delete(self):
-		ridx = self.prog.pairs.index(self)
+		ppairs = self.prog.pairs
+		ridx = ppairs.index(self)
 		mgrs = [model.removeItemManager(self) for model in self.models]
 		with nested(*mgrs):
-			pp = self.prog.pairs.pop(ridx)
+			pp = ppairs.pop(ridx)
 			if not pp.shape.isRest:
 				pp.shape.progPairs.remove(pp)
 				if not pp.shape.progPairs:
@@ -827,7 +828,7 @@ class ProgPair(SimplexAccessor):
 		par = self.prog
 		if isinstance(par.controller, Slider):
 			par = par.controller
-		return
+		return par
 
 	def treeData(self, column):
 		if column == 0:
@@ -882,7 +883,6 @@ class Progression(SimplexAccessor):
 			# Show the progression after the comboPairs
 			return len(self.controller.pairs)
 		return None
-
 
 	def treeParent(self):
 		return self.controller
@@ -986,20 +986,9 @@ class Progression(SimplexAccessor):
 			for model in self.models:
 				model.itemDataChanged(self.controller)
 
-
-
-
-
 	def siblingRename(self, shape, newName, currentLinks):
 		pass
 		# get name change
-
-
-
-
-
-
-
 
 	@stackable
 	def addFalloff(self, falloff):
@@ -1650,12 +1639,7 @@ class Combo(SimplexAccessor):
 	def treeChild(self, row):
 		if row == len(self.pairs):
 			return self.prog
-		try:
-			return self.pairs[row]
-		except IndexError:
-			print "BAD PAIRS", [i.name for i in self.pairs], row
-			raise
-			return None
+		return self.pairs[row]
 
 	def treeRow(self):
 		return self.group.items.index(self)
@@ -1844,7 +1828,7 @@ class Combo(SimplexAccessor):
 	def createShape(self, shapeName=None, tVal=None):
 		""" create a shape and add it to a progression """
 		pp, idx = self.prog.newProgPair(shapeName, tVal)
-		mgrs = [model.insertItemManager(self, idx) for model in self.models]
+		mgrs = [model.insertItemManager(self.prog, idx) for model in self.models]
 		with nested(*mgrs):
 			pp.prog = self.prog
 			self.prog.pairs.insert(idx, pp)
@@ -2072,6 +2056,16 @@ class Traversal(SimplexAccessor):
 				x = base if sfx.isdigit() else s.name
 			shapeNames.append(x)
 		return [i == self.name for i in shapeNames]
+
+	@stackable
+	def createShape(self, shapeName=None, tVal=None):
+		""" create a shape and add it to a progression """
+		pp, idx = self.prog.newProgPair(shapeName, tVal)
+		mgrs = [model.insertItemManager(self.prog, idx) for model in self.models]
+		with nested(*mgrs):
+			pp.prog = self.prog
+			self.prog.pairs.insert(idx, pp)
+		return pp
 
 	@classmethod
 	def loadV2(cls, simplex, progs, data):

--- a/scripts/SimplexUI/interfaceModel.py
+++ b/scripts/SimplexUI/interfaceModel.py
@@ -22,7 +22,7 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 from SimplexUI.Qt.QtCore import QAbstractItemModel, QModelIndex, Qt, QSortFilterProxyModel
 import re
 from contextlib import contextmanager
-from interfaceItems import (Falloff, Shape, ProgPair, Progression, Slider, ComboPair,
+from interfaceItems import (ProgPair, Progression, Slider, ComboPair,
 							Combo, Group, Simplex, Traversal, TravPair)
 
 # Hierarchy Helpers
@@ -247,14 +247,12 @@ class SimplexModel(ContextModel):
 			if index.column() == 0:
 				if isinstance(item, (Slider, Combo, Traversal)):
 					item.enabled = value == Qt.Checked
-					self.dataChanged.emit(index, index)
 					return True
 		elif role == Qt.EditRole:
 			item = index.internalPointer()
 			if index.column() == 0:
 				if isinstance(item, (Group, Slider, Combo, Traversal, ProgPair)):
 					item.name = value
-					self.dataChanged.emit(index, index)
 					return True
 
 			elif index.column() == 1:
@@ -281,138 +279,37 @@ class SimplexModel(ContextModel):
 	# These will be used to build the indexes
 	# and will be public for utility needs
 	def getChildItem(self, parent, row):
-		child = None
-		try:
-			if isinstance(parent, Simplex):
-				groups = parent.sliderGroups + parent.comboGroups + parent.traversalGroups
-				child = groups[row]
-			elif isinstance(parent, Group):
-				child = parent.items[row]
-			elif isinstance(parent, Slider):
-				child = parent.prog.pairs[row]
-			elif isinstance(parent, Combo):
-				if row == len(parent.pairs):
-					child = parent.prog
-				else:
-					child = parent.pairs[row]
-			elif isinstance(parent, Traversal):
-				if row == 0:
-					child = parent.progressCtrl
-				elif row == 1:
-					child = parent.multiplierCtrl
-				elif row == 2:
-					child = parent.prog
-			elif isinstance(parent, Progression):
-				child = parent.pairs[row]
-			elif parent is None:
-				if row == 0:
-					child = self.simplex
-			#elif isinstance(parent, ComboPair):
-			#elif isinstance(parent, ProgPair):
-			#elif isinstance(parent, TravPair):
-		except IndexError:
-			pass
-		return child
+		if parent is None and row == 0:
+			return self.simplex
+		return parent.treeChild(row)
 
 	def getItemRow(self, item):
-		row = None
-		try:
-			if isinstance(item, Group):
-				groups = item.simplex.sliderGroups + item.simplex.comboGroups + item.simplex.traversalGroups
-				row = groups.index(item)
-			elif isinstance(item, Slider):
-				row = item.group.items.index(item)
-			elif isinstance(item, ProgPair):
-				row = item.prog.pairs.index(item)
-			elif isinstance(item, Combo):
-				row = item.group.items.index(item)
-			elif isinstance(item, ComboPair):
-				row = item.combo.pairs.index(item)
-			elif isinstance(item, Traversal):
-				row = item.group.items.index(item)
-			elif isinstance(item, TravPair):
-				row = item.usageIndex()
-			elif isinstance(item, Progression):
-				if isinstance(item.controller, Slider):
-					row = len(item.pairs)
-				elif isinstance(item.controller, Combo):
-					row = len(item.pairs)
-				elif isinstance(item.controller, Traversal):
-					row = 2
-			elif isinstance(item, Simplex):
-				row = 0
-		except (ValueError, AttributeError) as e:
-			print "ERROR", e
-		return row
+		if item is not None:
+			return item.treeRow()
+		return None
 
 	def getParentItem(self, item):
-		par = None
-		if isinstance(item, Group):
-			par = item.simplex
-		elif isinstance(item, Slider):
-			par = item.group
-		elif isinstance(item, Progression):
-			par = item.controller
-		elif isinstance(item, Combo):
-			par = item.group
-		elif isinstance(item, ComboPair):
-			par = item.combo
-		elif isinstance(item, TravPair):
-			par = item.traversal
-		elif isinstance(item, Traversal):
-			par = item.group
-		elif isinstance(item, ProgPair):
-			par = item.prog
-			if isinstance(par.controller, Slider):
-				par = par.controller
-		return par
+		if item is not None:
+			return item.treeParent()
+		return None
 
 	def getItemRowCount(self, item):
-		ret = 0
-		if isinstance(item, Simplex):
-			ret = len(item.sliderGroups) + len(item.comboGroups) + len(item.traversalGroups)
-		elif isinstance(item, Group):
-			ret = len(item.items)
-		elif isinstance(item, Slider):
-			ret = len(item.prog.pairs)
-		elif isinstance(item, Combo):
-			ret = len(item.pairs) + 1
-		elif isinstance(item, Traversal):
-			ret = 3
-		elif isinstance(item, TravPair):
-			ret = 0
-		elif isinstance(item, Progression):
-			ret = len(item.pairs)
-		elif item is None:
-			# Null parent means 1 row that is the simplex object
-			ret = 1
-		return ret
+		# Null parent means 1 row that is the simplex object
+		if item is None:
+			return 1
+		return item.treeChildCount()
 
 	def getItemData(self, item, column, role):
 		if role in (Qt.DisplayRole, Qt.EditRole):
-			if column == 0:
-				if isinstance(item, (Simplex, Group, Slider, ProgPair, Combo,
-						 Traversal, ComboPair, ProgPair, TravPair)):
-					return item.name
-				elif isinstance(item, Progression):
-					return "SHAPES"
-				elif isinstance(item, TravPair):
-					return item.usage.upper()
-			elif column == 1:
-				if isinstance(item, (Slider, ComboPair, TravPair)):
-					return item.value
-				return None
-			elif column == 2:
-				if isinstance(item, ProgPair):
-					return item.value
-				elif isinstance(item, TravPair):
-					return item.usage
-				return None
+			return item.treeData(column)
+
 		elif role == Qt.CheckStateRole:
+			chk = None
 			if column == 0:
-				if isinstance(item, (Slider, Combo, Traversal)):
-					return Qt.Checked if item.enabled else Qt.Unchecked
-				return None
+				chk = item.treeChecked()
+			if chk is not None:
+				chk = Qt.Checked if chk else Qt.Unchecked
+			return chk
 		return None
 
 	def updateTickValues(self, updatePairs):
@@ -457,7 +354,6 @@ class SimplexModel(ContextModel):
 			self.dataChanged.emit(idx, idx)
 
 
-
 # VIEW MODELS
 class BaseProxyModel(QSortFilterProxyModel):
 	''' Holds the common item/index translation code '''
@@ -481,6 +377,15 @@ class BaseProxyModel(QSortFilterProxyModel):
 			source.invalidate()
 		super(BaseProxyModel, self).invalidate()
 
+	def invalidateFilter(self):
+		source = self.sourceModel()
+		if isinstance(source, QSortFilterProxyModel):
+			source.invalidateFilter()
+		super(BaseProxyModel, self).invalidateFilter()
+
+	def filterAcceptsRow(self, sourceRow, sourceParent):
+		return True
+
 
 class SliderModel(BaseProxyModel):
 	def filterAcceptsRow(self, sourceRow, sourceParent):
@@ -488,7 +393,7 @@ class SliderModel(BaseProxyModel):
 		if sourceIndex.isValid():
 			item = self.sourceModel().itemFromIndex(sourceIndex)
 			if isinstance(item, Group):
-				if item.groupType != Slider:
+				if item.groupType is not Slider:
 					return False
 		return super(SliderModel, self).filterAcceptsRow(sourceRow, sourceParent)
 
@@ -499,7 +404,7 @@ class ComboModel(BaseProxyModel):
 		if sourceIndex.isValid():
 			item = self.sourceModel().itemFromIndex(sourceIndex)
 			if isinstance(item, Group):
-				if item.groupType != Combo:
+				if item.groupType is not Combo:
 					return False
 		return super(ComboModel, self).filterAcceptsRow(sourceRow, sourceParent)
 
@@ -510,7 +415,7 @@ class TraversalModel(BaseProxyModel):
 		if sourceIndex.isValid():
 			item = self.sourceModel().itemFromIndex(sourceIndex)
 			if isinstance(item, Group):
-				if item.groupType != Traversal:
+				if item.groupType is not Traversal:
 					return False
 		return super(TraversalModel, self).filterAcceptsRow(sourceRow, sourceParent)
 
@@ -611,7 +516,8 @@ class ComboFilterModel(SimplexFilterModel):
 		self.filterShapes = True
 
 	def filterAcceptsRow(self, sourceRow, sourceParent):
-		column = 0 #always sort by the first column #column = self.filterKeyColumn()
+		#always sort by the first column #column = self.filterKeyColumn()
+		column = 0
 		sourceIndex = self.sourceModel().index(sourceRow, column, sourceParent)
 		if sourceIndex.isValid():
 			data = self.sourceModel().itemFromIndex(sourceIndex)

--- a/scripts/SimplexUI/interfaceModel.py
+++ b/scripts/SimplexUI/interfaceModel.py
@@ -288,9 +288,13 @@ class SimplexModel(ContextModel):
 		return parent.treeChild(row)
 
 	def getItemRow(self, item):
+		if item is None:
+			return None
 		return item.treeRow()
 
 	def getParentItem(self, item):
+		if item is None:
+			return None
 		return item.treeParent()
 
 	def getItemRowCount(self, item):

--- a/scripts/SimplexUI/interfaceModelTrees.py
+++ b/scripts/SimplexUI/interfaceModelTrees.py
@@ -17,11 +17,11 @@ You should have received a copy of the GNU Lesser General Public License
 along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 '''
 
-from SimplexUI.Qt.QtGui import QRegExpValidator
-from SimplexUI.Qt.QtCore import Qt, QModelIndex, QItemSelection, QItemSelectionModel, QRegExp
-from SimplexUI.Qt.QtWidgets import QTreeView, QApplication, QMenu, QLineEdit, QStyledItemDelegate
-from SimplexUI.dragFilter import DragFilter
-from SimplexUI.interfaceItems import Group
+from .Qt.QtGui import QRegExpValidator
+from .Qt.QtCore import Qt, QModelIndex, QItemSelection, QItemSelectionModel, QRegExp
+from .Qt.QtWidgets import QTreeView, QApplication, QMenu, QLineEdit, QStyledItemDelegate
+from .dragFilter import DragFilter
+from .interfaceItems import Group
 
 class SimplexNameDelegate(QStyledItemDelegate):
 	def __init__(self, parent=None):

--- a/scripts/SimplexUI/interfaceModel_Test.py
+++ b/scripts/SimplexUI/interfaceModel_Test.py
@@ -6,10 +6,10 @@ import os, sys
 base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, base)
 
-from SimplexUI.interfaceModel import (Simplex, Slider, SimplexModel, SliderModel, SliderFilterModel,
+from .interfaceModel import (Simplex, Slider, SimplexModel, SliderModel, SliderFilterModel,
 							ComboModel, ComboFilterModel, TraversalModel, TraversalFilterModel)
-from SimplexUI.Qt.QtWidgets import QTreeView, QApplication, QPushButton, QVBoxLayout, QWidget
-from SimplexUI.Qt.QtCore import QModelIndex
+from .Qt.QtWidgets import QTreeView, QApplication, QPushButton, QVBoxLayout, QWidget
+from .Qt.QtCore import QModelIndex
 
 
 # HELPERS

--- a/scripts/SimplexUI/interfaceModel_Test.py
+++ b/scripts/SimplexUI/interfaceModel_Test.py
@@ -1,6 +1,8 @@
-#pylint:disable=E0611,E0401
 import os, sys
 
+# Add the parent folder to the path so I can import SimplexUI
+# Means I can run this test code from inside the module and
+# keep everything together
 base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, base)
 

--- a/scripts/SimplexUI/interfaceModel_Test.py
+++ b/scripts/SimplexUI/interfaceModel_Test.py
@@ -1,6 +1,13 @@
-import os, sys, json
-from interfaceModel import *
+#pylint:disable=E0611,E0401
+import os, sys
+
+base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, base)
+
+from SimplexUI.interfaceModel import (Simplex, Slider, SimplexModel, SliderModel, SliderFilterModel,
+							ComboModel, ComboFilterModel, TraversalModel, TraversalFilterModel)
 from SimplexUI.Qt.QtWidgets import QTreeView, QApplication, QPushButton, QVBoxLayout, QWidget
+from SimplexUI.Qt.QtCore import QModelIndex
 
 
 # HELPERS
@@ -31,9 +38,9 @@ def showTree(model):
 
 def buildDummySystem(path, name="Face"):
 	if path.endswith('.json'):
-		simp = Simplex.buildSystemFromJson(path, None)
+		simp = Simplex.buildSystemFromFile(path)
 	elif path.endswith('.smpx'):
-		simp = Simplex.buildSystemFromSmpx(path)
+		simp = Simplex.buildSystemFromFile(path)
 	else:
 		raise IOError("Filepath is not .smpx or .json")
 	return simp
@@ -42,7 +49,7 @@ def buildDummySystem(path, name="Face"):
 
 # DISPLAY TESTS
 def testSliderDisplay(smpxPath, applyFilter=True):
-	simp = Simplex.buildSystemFromSmpx(smpxPath)
+	simp = Simplex.buildSystemFromFile(smpxPath)
 	model = SimplexModel(simp, None)
 	model = SliderModel(model)
 	if applyFilter:
@@ -50,7 +57,7 @@ def testSliderDisplay(smpxPath, applyFilter=True):
 	showTree(model)
 
 def testComboDisplay(smpxPath, applyFilter=True):
-	simp = Simplex.buildSystemFromSmpx(smpxPath)
+	simp = Simplex.buildSystemFromFile(smpxPath)
 	model = SimplexModel(simp, None)
 	model = ComboModel(model)
 	if applyFilter:
@@ -101,7 +108,8 @@ def testNewSlider():
 	expandRecursive(tv, fmodel)
 	topWid.show()
 
-	newSlider = lambda: Slider.createSlider('NewSlider', simp)
+	def newSlider(): return Slider.createSlider('NewSlider', simp)
+
 	btn.clicked.connect(newSlider)
 
 	sys.exit(app.exec_())
@@ -109,8 +117,12 @@ def testNewSlider():
 def testDeleteBase(path):
 	simp = buildDummySystem(path)
 	model = SimplexModel(simp, None)
-	model = SliderModel(model)
-	model = SliderFilterModel(model)
+
+	#model = SliderModel(model)
+	#model = SliderFilterModel(model)
+
+	model = ComboModel(model)
+	#model = ComboFilterModel(model)
 
 	app = QApplication(sys.argv)
 
@@ -133,7 +145,9 @@ def testDeleteBase(path):
 		sel = tv.selectedIndexes()
 		sel = [i for i in sel if i.column() == 0]
 		items = [s.model().itemFromIndex(s) for s in sel]
-		items[0].delete()
+		item = items[0]
+		print "Deleting", type(item), item.name
+		item.delete()
 		tv.model().invalidateFilter()
 
 	btn.clicked.connect(delCallback)
@@ -167,13 +181,13 @@ def testNewChild(path):
 		sel = tv.selectedIndexes()
 		sel = [i for i in sel if i.column() == 0]
 		items = [s.model().itemFromIndex(s) for s in sel]
-		item = items[0]
+		#item = items[0]
 
 		# TODO
 		# find the child type of item
 		# make a new one of those
 
-		tv.model().invalidateFilter()
+		#tv.model().invalidateFilter()
 
 	btn.clicked.connect(newCallback)
 
@@ -184,17 +198,17 @@ def testNewChild(path):
 if __name__ == "__main__":
 	#basePath = r'D:\Users\tyler\Documents\GitHub\Simplex\scripts\SimplexUI\build'
 	basePath = r'D:\Users\tyler\Documents\GitHub\Simplex\Useful'
-	#path = os.path.join(basePath, 'Themale_Simplex_v005_Split.smpx')
+	#path = os.path.join(basePath, 'male_Simplex_v005_Split.smpx')
 	#path = os.path.join(basePath, 'sphere_abcd_50.smpx')
-	path = os.path.join(basePath, 'male_traversal3.json')
+	#path = os.path.join(basePath, 'male_traversal3.json')
+	path = os.path.join(basePath, 'SquareTest_Floater.json')
 
 	# Only works for one at a time
 	#testEmptySimplex()
 	#testBaseDisplay(path)
 	#testSliderDisplay(path, applyFilter=True)
 	#testComboDisplay(path, applyFilter=True)
-	testTraversalDisplay(path, applyFilter=True)
+	#testTraversalDisplay(path, applyFilter=True)
 	#testNewSlider()
-	#testDeleteBase()
-
+	testDeleteBase(path)
 

--- a/scripts/SimplexUI/mayaInterface.py
+++ b/scripts/SimplexUI/mayaInterface.py
@@ -598,11 +598,15 @@ class DCC(object):
 		nn = self.ctrl.replace(self.name, name)
 		self.ctrl = cmds.rename(self.ctrl, nn)
 
+		oldNodeName = self.shapeNode
 		nn = self.shapeNode.replace(self.name, name)
 		self.shapeNode = cmds.rename(self.shapeNode, nn)
 
 		nn = self.op.replace(self.name, name)
 		self.op = cmds.rename(self.op, nn)
+
+		for shape in self.simplex.shapes:
+			shape.thing = shape.thing.replace(oldNodeName, self.shapeNode)
 
 		self.name = name
 

--- a/scripts/SimplexUI/mayaInterface.py
+++ b/scripts/SimplexUI/mayaInterface.py
@@ -1242,6 +1242,9 @@ class DCC(object):
 		floatShapes = self.simplex.getFloatingShapes()
 		floatShapes = [i.thing for i in floatShapes]
 
+		shapeIdx = combo.prog.getShapeIndex(shape)
+		tVal = combo.prog.pairs[shapeIdx].value
+
 		with disconnected(self.op) as cnx:
 			sliderCnx = cnx[self.op]
 			# zero all slider vals on the op
@@ -1251,7 +1254,7 @@ class DCC(object):
 			with disconnected(floatShapes):
 				# set the combo values
 				for pair in combo.pairs:
-					cmds.setAttr(sliderCnx[pair.slider.thing], pair.value)
+					cmds.setAttr(sliderCnx[pair.slider.thing], pair.value * tVal)
 
 				extracted = cmds.duplicate(self.mesh, name="{0}_Extract".format(shape.name))[0]
 				self._clearShapes(extracted)

--- a/scripts/SimplexUI/simplexInterfaceDialog.py
+++ b/scripts/SimplexUI/simplexInterfaceDialog.py
@@ -572,7 +572,7 @@ class SimplexDialog(Window):
 			return
 		parItem = pars[0]
 		parItem.createShape()
-		#self.uiSliderTREE.model().invalidateFilter()
+		self.uiSliderTREE.model().invalidateFilter()
 
 	def sliderTreeDelete(self):
 		idxs = self.uiSliderTREE.getSelectedIndexes()
@@ -588,7 +588,7 @@ class SimplexDialog(Window):
 
 		for r in roots:
 			r.delete()
-		#self.uiSliderTREE.model().invalidateFilter()
+		self.uiSliderTREE.model().invalidateFilter()
 
 
 	# Top Right Corner Buttons
@@ -598,7 +598,7 @@ class SimplexDialog(Window):
 		roots = makeUnique([i.model().itemFromIndex(i) for i in roots])
 		for r in roots:
 			r.delete()
-		#self.uiComboTREE.model().invalidateFilter()
+		self.uiComboTREE.model().invalidateFilter()
 
 	def newActiveCombo(self):
 		if self.simplex is None:
@@ -630,7 +630,7 @@ class SimplexDialog(Window):
 
 		parItem = pars[0].model().itemFromIndex(pars[0]) if pars else None
 		parItem.createShape()
-		#self.uiComboTREE.model().invalidateFilter()
+		self.uiComboTREE.model().invalidateFilter()
 
 	def newComboGroup(self):
 		if self.simplex is None:

--- a/scripts/SimplexUI/simplexInterfaceDialog.py
+++ b/scripts/SimplexUI/simplexInterfaceDialog.py
@@ -21,29 +21,28 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 # Ignore a bunch of linter warnings that show up because of my choice of abstraction
 #pylint: disable=unused-argument,too-many-public-methods,relative-import
 #pylint: disable=too-many-statements,no-self-use,missing-docstring
-import os, sys, re, json, copy, weakref
-from functools import wraps
+import os, sys, re, json, weakref
 from contextlib import contextmanager
 
 # This module imports QT from PyQt4, PySide or PySide2
 # Depending on what's available
 from SimplexUI.Qt import QtCompat
-from SimplexUI.Qt.QtCore import Signal, Slot
+from SimplexUI.Qt.QtCore import Signal
 from SimplexUI.Qt.QtCore import Qt, QSettings
 from SimplexUI.Qt.QtGui import QStandardItemModel
-from SimplexUI.Qt.QtWidgets import QMessageBox, QInputDialog, QMenu, QApplication, QTreeView, QDataWidgetMapper
+from SimplexUI.Qt.QtWidgets import QMessageBox, QInputDialog, QApplication
 from SimplexUI.Qt.QtWidgets import QMainWindow, QProgressDialog, QPushButton, QComboBox, QCheckBox
 
 from utils import toPyObject, getUiFile, getNextName, makeUnique, naturalSortKey
 
-from interfaceItems import (ProgPair, Slider, Combo, Group, Simplex, Shape, Stack, Falloff)
+from interfaceItems import (ProgPair, Slider, Combo, Group, Simplex, Stack)
 
 from interfaceModel import (SliderModel, ComboModel, ComboFilterModel, SliderFilterModel,
 							coerceIndexToChildType, coerceIndexToParentType, coerceIndexToRoots,
-							SliderGroupModel, FalloffModel, FalloffDataModel, SimplexModel)
+							SimplexModel)
 
-from interface import undoContext, rootWindow, DCC, DISPATCH
-from plugInterface import loadPlugins, buildToolMenu, buildRightClickMenu
+from interface import DCC
+from plugInterface import loadPlugins, buildToolMenu
 from interfaceModelTrees import SliderTree, ComboTree
 
 from traversalDialog import TraversalDialog
@@ -537,7 +536,8 @@ class SimplexDialog(QMainWindow):
 			QMessageBox.warning(self, 'Warning', message)
 			return
 		Group.createGroup(str(newName), self.simplex, groupType=Slider)
-		self.uiSliderTREE.model().sourceModel().invalidateFilter()
+		#self.uiSliderTREE.model().invalidateFilter()
+		#self.uiComboTREE.model().invalidateFilter()
 
 	def newSlider(self):
 		if self.simplex is None:
@@ -564,7 +564,7 @@ class SimplexDialog(QMainWindow):
 			return
 		parItem = pars[0]
 		parItem.createShape()
-		self.uiSliderTREE.model().invalidateFilter()
+		#self.uiSliderTREE.model().invalidateFilter()
 
 	def sliderTreeDelete(self):
 		idxs = self.uiSliderTREE.getSelectedIndexes()
@@ -580,7 +580,7 @@ class SimplexDialog(QMainWindow):
 
 		for r in roots:
 			r.delete()
-		self.uiSliderTREE.model().invalidateFilter()
+		#self.uiSliderTREE.model().invalidateFilter()
 
 
 	# Top Right Corner Buttons
@@ -590,7 +590,7 @@ class SimplexDialog(QMainWindow):
 		roots = makeUnique([i.model().itemFromIndex(i) for i in roots])
 		for r in roots:
 			r.delete()
-		self.uiComboTREE.model().invalidateFilter()
+		#self.uiComboTREE.model().invalidateFilter()
 
 	def newActiveCombo(self):
 		if self.simplex is None:
@@ -620,7 +620,7 @@ class SimplexDialog(QMainWindow):
 			return
 		parItem = pars[0]
 		parItem.createShape()
-		pars = self.uiComboTREE.invalidateFilter()
+		#pars = self.uiComboTREE.invalidateFilter()
 
 	def newComboGroup(self):
 		if self.simplex is None:
@@ -633,7 +633,8 @@ class SimplexDialog(QMainWindow):
 			QMessageBox.warning(self, 'Warning', message)
 			return
 		Group.createGroup(str(newName), self.simplex, groupType=Combo)
-		self.uiComboTREE.model().sourceModel().invalidateFilter()
+		#self.uiComboTREE.model().invalidateFilter()
+		#self.uiSliderTREE.model().invalidateFilter()
 
 
 	# Bottom right corner buttons

--- a/scripts/SimplexUI/simplexInterfaceDialog.py
+++ b/scripts/SimplexUI/simplexInterfaceDialog.py
@@ -31,7 +31,7 @@ from SimplexUI.Qt.QtCore import Signal
 from SimplexUI.Qt.QtCore import Qt, QSettings
 from SimplexUI.Qt.QtGui import QStandardItemModel
 from SimplexUI.Qt.QtWidgets import QMessageBox, QInputDialog, QApplication
-from SimplexUI.Qt.QtWidgets import QMainWindow, QProgressDialog, QPushButton, QComboBox, QCheckBox
+from SimplexUI.Qt.QtWidgets import QProgressDialog, QPushButton, QComboBox, QCheckBox
 
 from utils import toPyObject, getUiFile, getNextName, makeUnique, naturalSortKey
 
@@ -51,8 +51,10 @@ from falloffDialog import FalloffDialog
 try:
 	# This module is unique to Blur Studio
 	import blurdev
+	from blurdev.gui import Window
 except ImportError:
 	blurdev = None
+	from SimplexUI.Qt.QtWidgets import QMainWindow as Window
 
 NAME_CHECK = re.compile(r'[A-Za-z][\w.]*')
 
@@ -73,7 +75,7 @@ def signalsBlocked(item):
 		item.blockSignals(False)
 
 
-class SimplexDialog(QMainWindow):
+class SimplexDialog(Window):
 	''' The main ui for simplex '''
 	simplexLoaded = Signal()
 	def __init__(self, parent=None, dispatch=None):
@@ -621,12 +623,14 @@ class SimplexDialog(QMainWindow):
 		self.uiComboTREE.setItemSelection([newCombo])
 
 	def newComboShape(self):
-		pars = self.uiComboTREE.getSelectedItems(Combo)
+		parIdxs = self.uiComboTREE.getSelectedIndexes()
+		pars = coerceIndexToParentType(parIdxs, Combo)
 		if not pars:
 			return
-		parItem = pars[0]
+
+		parItem = pars[0].model().itemFromIndex(pars[0]) if pars else None
 		parItem.createShape()
-		#pars = self.uiComboTREE.invalidateFilter()
+		#self.uiComboTREE.model().invalidateFilter()
 
 	def newComboGroup(self):
 		if self.simplex is None:

--- a/scripts/SimplexUI/tools/dummyPlugins/__init__.py
+++ b/scripts/SimplexUI/tools/dummyPlugins/__init__.py
@@ -20,7 +20,9 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 import os
 __all__ = [m for m in os.listdir(os.path.dirname(__file__)) if m != "__init__.py"]
 __all__ = sorted([m[:-3] for m in __all__ if m.endswith(".py")])
-for x in __all__:
-	__import__(x, locals(), globals())
-del os, x, m
+if __all__:
+	for x in __all__:
+		__import__(x, locals(), globals())
+	del x
+del os, m
 

--- a/scripts/SimplexUI/tools/dummyTools.py
+++ b/scripts/SimplexUI/tools/dummyTools.py
@@ -19,7 +19,7 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 #pylint: disable=no-self-use, fixme, missing-docstring
 import dummyPlugins as plugins
 import genericPlugins
-from SimplexUI.Qt.QtWidgets import QMenu
+from ..Qt.QtWidgets import QMenu
 
 # Registration class
 def loadPlugins():

--- a/scripts/SimplexUI/tools/genericPlugins/_builtins.py
+++ b/scripts/SimplexUI/tools/genericPlugins/_builtins.py
@@ -1,9 +1,9 @@
 #pylint:disable=unused-variable
 from functools import partial
-from SimplexUI.Qt.QtWidgets import QAction, QMenu, QWidgetAction, QCheckBox
-from SimplexUI.Qt.QtCore import Qt
-from SimplexUI.interfaceItems import Slider, Combo, ComboPair, ProgPair, Group, Progression
-from SimplexUI.interfaceModel import coerceIndexToType
+from ...Qt.QtWidgets import QAction, QMenu, QWidgetAction, QCheckBox
+from ...Qt.QtCore import Qt
+from ...interfaceItems import Slider, Combo, ComboPair, ProgPair, Group, Progression
+from ...interfaceModel import coerceIndexToType
 
 
 def registerContext(tree, clickIdx, indexes, menu):

--- a/scripts/SimplexUI/tools/genericPlugins/checkPossibleCombos.py
+++ b/scripts/SimplexUI/tools/genericPlugins/checkPossibleCombos.py
@@ -1,7 +1,7 @@
-from SimplexUI.Qt.QtWidgets import QAction, QProgressDialog, QFileDialog
-from SimplexUI.Qt import QtCompat
-from SimplexUI.comboCheckDialog import ComboCheckDialog
-from SimplexUI.interfaceItems import Slider
+from ...Qt.QtWidgets import QAction, QProgressDialog, QFileDialog
+from ...Qt import QtCompat
+from ...comboCheckDialog import ComboCheckDialog
+from ...interfaceItems import Slider
 from functools import partial
 
 def registerTool(window, menu):
@@ -17,6 +17,6 @@ def registerContext(tree, clickIdx, indexes, menu):
 
 def checkPossibleCombosInterface(window):
 	sliders = window.uiSliderTREE.getSelectedItems(typ=Slider)
-	ccd = ComboCheckDialog(sliders, window)
+	ccd = ComboCheckDialog(sliders, parent=window)
 	ccd.show()
 

--- a/scripts/SimplexUI/tools/genericPlugins/exportSplit.py
+++ b/scripts/SimplexUI/tools/genericPlugins/exportSplit.py
@@ -1,5 +1,5 @@
-from SimplexUI.Qt.QtWidgets import QAction, QProgressDialog, QMessageBox
-from SimplexUI.Qt import QtCompat
+from ...Qt.QtWidgets import QAction, QProgressDialog, QMessageBox
+from ...Qt import QtCompat
 from functools import partial
 try:
 	import numpy as np

--- a/scripts/SimplexUI/tools/genericPlugins/showFalloffs.py
+++ b/scripts/SimplexUI/tools/genericPlugins/showFalloffs.py
@@ -1,4 +1,4 @@
-from SimplexUI.Qt.QtWidgets import QAction
+from ...Qt.QtWidgets import QAction
 
 def registerTool(window, menu):
 	editFalloffsACT = QAction("Edit Falloffs ...", window)

--- a/scripts/SimplexUI/tools/genericPlugins/showTraversals.py
+++ b/scripts/SimplexUI/tools/genericPlugins/showTraversals.py
@@ -1,4 +1,4 @@
-from SimplexUI.Qt.QtWidgets import QAction
+from ...Qt.QtWidgets import QAction
 
 def registerTool(window, menu):
 	showTraversalsACT = QAction("Show Traversals ...", window)

--- a/scripts/SimplexUI/tools/genericPlugins/simplexUvTransfer.py
+++ b/scripts/SimplexUI/tools/genericPlugins/simplexUvTransfer.py
@@ -1,0 +1,79 @@
+from alembic.Abc import OArchive, IArchive
+from alembic.AbcGeom import IXform
+from blur3d.api.classes.mesh import Mesh
+from blur3d.api.classes import abc
+import numpy as np
+from ...commands.uvTransfer import getVertCorrelation, applyTransfer
+from ... import OGAWA
+
+def _loadJSString(srcSmpxPath):
+	''' Get the json string out of a .smpx file '''
+	iarch = IArchive(str(srcSmpxPath))
+	top = iarch.getTop()
+	par = top.children[0]
+	parName = par.getName()
+	par = IXform(top, parName)
+
+	systemSchema = par.getSchema()
+	props = systemSchema.getUserProperties()
+	prop = props.getProperty("simplex")
+	jsString = prop.getValue()
+	return jsString, parName
+
+def simplexUvTransfer(srcSmpxPath, tarPath, outPath, srcUvPath=None, tol=0.0001, pBar=None):
+	""" Transfer a simplex system onto a mesh through UV space
+
+	Arguments:
+		srcSmpxPath (str): The path to the source .smpx file
+		tarPath (str): The path to the mesh to recieve the blendshapes
+		outPath (str): The .smpx path that will be written
+		srcUvPath (str): If the .smpx file doesn't have UV's, then the UV's
+			from this mesh wil be used. Defaults to None
+		tol (float): The tolerance for checking if a UV is outside of a poly
+		pBar (QProgressDialog): Optional progress bar
+	"""
+	if pBar is not None:
+		pBar.setLabelText("Loading Source Mesh")
+		from Qt.QtWidgets import QApplication
+		QApplication.processEvents()
+
+	srcUvPath = srcUvPath or srcSmpxPath
+	if srcUvPath.endswith('.abc') or srcUvPath.endswith('.smpx'):
+		src = Mesh.loadAbc(srcUvPath, ensureWinding=False)
+	elif srcUvPath.endswith('.obj'):
+		src = Mesh.loadObj(srcUvPath, ensureWinding=False)
+	srcVerts = abc.getSampleArray(abc.getMesh(srcSmpxPath))
+
+	if pBar is not None:
+		pBar.setLabelText("Loading Target Mesh")
+		from Qt.QtWidgets import QApplication
+		QApplication.processEvents()
+	if tarPath.endswith('.abc'):
+		tar = Mesh.loadAbc(tarPath, ensureWinding=False)
+	elif tarPath.endswith('.obj'):
+		tar = Mesh.loadObj(tarPath, ensureWinding=False)
+
+	srcFaces = src.faceVertArray
+	srcUvFaces = src.uvFaceMap['default']
+	srcUvs = np.array(src.uvMap['default'])
+
+	tarFaces = tar.faceVertArray
+	tarUvFaces = tar.uvFaceMap['default']
+	tarUvs = np.array(tar.uvMap['default'])
+	oldTarVerts = np.array(tar.vertArray)
+
+	corr = getVertCorrelation(srcUvFaces, srcUvs, tarFaces, tarUvFaces, tarUvs, tol=tol, pBar=pBar)
+	tarVerts = applyTransfer(srcVerts, srcFaces, corr, len(oldTarVerts))
+
+	# Apply as a delta
+	deltas = tarVerts - tarVerts[0][None, ...]
+	writeVerts = oldTarVerts[None, ...] + deltas
+
+	jsString, name = _loadJSString(srcSmpxPath)
+	oarch = OArchive(str(outPath), OGAWA) # false for HDF5
+	abc.buildAbc(
+		oarch, writeVerts, tarFaces, uvs=tarUvs, uvFaces=tarUvFaces,
+		name=name, shapeSuffix='', propDict=dict(simplex=jsString)
+	)
+
+

--- a/scripts/SimplexUI/tools/genericPlugins/unsubdivide.py
+++ b/scripts/SimplexUI/tools/genericPlugins/unsubdivide.py
@@ -1,0 +1,44 @@
+import os
+from ...Qt.QtWidgets import QAction, QProgressDialog, QMessageBox
+from ...Qt import QtCompat
+from functools import partial
+from ...commands.unsubdivide import unsubdivideSimplex
+
+try:
+	import imathnumpy
+except ImportError:
+	imathnumpy = None
+
+def registerTool(window, menu):
+	if imathnumpy is not None:
+		exportUnsubACT = QAction("Un Subdivide Smpx ...", window)
+		menu.addAction(exportUnsubACT)
+		exportUnsubACT.triggered.connect(partial(exportUnsubInterface, window))
+
+def exportUnsubInterface(window):
+	if imathnumpy is None:
+		QMessageBox.warning(window, "No ImathToNumpy", "ImathToNumpy is not available here, and it is required to unsubdivide a system")
+		return
+
+	path, _filter = QtCompat.QFileDialog.getOpenFileName(window, "Un Subdivide", "", "Simplex (*.smpx)")
+
+	if not path:
+		return
+
+	outPath = path.replace(".smpx", "_UNSUB.smpx")
+	if path == outPath:
+		QMessageBox.warning(window, "Unable to rename smpx file: {}".format(path))
+		return
+
+	if os.path.isfile(outPath):
+		btns = QMessageBox.Ok | QMessageBox.Cancel
+		msg = "Unsub file already exists.\n{0}\nOverwrite?".format(outPath)
+		response = QMessageBox.question(window, "File already exists", msg, btns)
+		if not response & QMessageBox.Ok:
+			return
+
+	pBar = QProgressDialog("Exporting Unsubdivided smpx File", "Cancel", 0, 100, window)
+	pBar.show()
+	unsubdivideSimplex(path, outPath, pBar=pBar)
+	pBar.close()
+

--- a/scripts/SimplexUI/tools/mayaPlugins/exportOther.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/exportOther.py
@@ -1,6 +1,6 @@
 import maya.cmds as cmds
-from SimplexUI.Qt.QtWidgets import QAction, QProgressDialog
-from SimplexUI.Qt import QtCompat
+from ...Qt.QtWidgets import QAction, QProgressDialog
+from ...Qt import QtCompat
 from functools import partial
 
 def registerTool(window, menu):

--- a/scripts/SimplexUI/tools/mayaPlugins/extractProgressives.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/extractProgressives.py
@@ -1,7 +1,7 @@
 import maya.cmds as cmds
-from SimplexUI.Qt.QtWidgets import QAction
-from SimplexUI.interfaceItems import Slider
-from SimplexUI.interfaceModel import coerceIndexToType
+from ...Qt.QtWidgets import QAction
+from ...interfaceItems import Slider
+from ...interfaceModel import coerceIndexToType
 from functools import partial
 
 def registerTool(window, menu):

--- a/scripts/SimplexUI/tools/mayaPlugins/generateShapeIncrementals.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/generateShapeIncrementals.py
@@ -1,7 +1,7 @@
 import maya.cmds as cmds
-from SimplexUI.Qt.QtWidgets import QAction, QInputDialog, QMessageBox
-from SimplexUI.interfaceItems import Slider, Combo
-from SimplexUI.interfaceModel import coerceIndexToType
+from ...Qt.QtWidgets import QAction, QInputDialog, QMessageBox
+from ...interfaceItems import Slider, Combo
+from ...interfaceModel import coerceIndexToType
 from functools import partial
 
 def registerContext(tree, clickIdx, indexes, menu):

--- a/scripts/SimplexUI/tools/mayaPlugins/importObjs.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/importObjs.py
@@ -1,6 +1,6 @@
 import maya.cmds as cmds
-from SimplexUI.Qt.QtWidgets import QAction, QProgressDialog, QFileDialog
-from SimplexUI.Qt import QtCompat
+from ...Qt.QtWidgets import QAction, QProgressDialog, QFileDialog
+from ...Qt import QtCompat
 from functools import partial
 
 def registerTool(window, menu):

--- a/scripts/SimplexUI/tools/mayaPlugins/makeShelfBtn.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/makeShelfBtn.py
@@ -1,6 +1,6 @@
 import os
 import maya.cmds as cmds
-from SimplexUI.Qt.QtWidgets import QAction
+from ...Qt.QtWidgets import QAction
 
 
 dn = os.path.dirname

--- a/scripts/SimplexUI/tools/mayaPlugins/relaxToSelection.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/relaxToSelection.py
@@ -1,5 +1,5 @@
 import maya.cmds as cmds
-from SimplexUI.Qt.QtWidgets import QAction
+from ...Qt.QtWidgets import QAction
 
 def registerTool(window, menu):
 	relaxToSelectionACT = QAction("Relax To Selection", window)

--- a/scripts/SimplexUI/tools/mayaPlugins/reloadDefinition.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/reloadDefinition.py
@@ -1,5 +1,5 @@
 import maya.cmds as cmds
-from SimplexUI.Qt.QtWidgets import QAction
+from ...Qt.QtWidgets import QAction
 from functools import partial
 
 def registerTool(window, menu):

--- a/scripts/SimplexUI/tools/mayaPlugins/snapToNeutral.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/snapToNeutral.py
@@ -1,5 +1,5 @@
 import maya.cmds as cmds
-from SimplexUI.Qt.QtWidgets import QAction
+from ...Qt.QtWidgets import QAction
 from functools import partial
 
 def registerTool(window, menu):

--- a/scripts/SimplexUI/tools/mayaPlugins/softSelectToCluster.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/softSelectToCluster.py
@@ -1,7 +1,7 @@
 import maya.cmds as cmds
 import maya.OpenMaya as om
 
-from SimplexUI.Qt.QtWidgets import QAction
+from ...Qt.QtWidgets import QAction
 
 def registerTool(window, menu):
 	softSelectToClusterACT = QAction("Soft Select To Cluster", window)

--- a/scripts/SimplexUI/tools/mayaPlugins/tweakMix.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/tweakMix.py
@@ -1,8 +1,8 @@
 import maya.cmds as cmds
-from SimplexUI.Qt.QtWidgets import QAction
-from SimplexUI.mayaInterface import disconnected
-from SimplexUI.interfaceItems import Combo, ProgPair
-from SimplexUI.interfaceModel import coerceIndexToType
+from ...Qt.QtWidgets import QAction
+from ...mayaInterface import disconnected
+from ...interfaceItems import Combo, ProgPair
+from ...interfaceModel import coerceIndexToType
 from functools import partial
 
 def registerTool(window, menu):

--- a/scripts/SimplexUI/tools/mayaPlugins/updateRestShape.py
+++ b/scripts/SimplexUI/tools/mayaPlugins/updateRestShape.py
@@ -1,6 +1,6 @@
 import textwrap
 import maya.cmds as cmds
-from SimplexUI.Qt.QtWidgets import QAction, QMessageBox
+from ...Qt.QtWidgets import QAction, QMessageBox
 from functools import partial
 
 def registerTool(window, menu):
@@ -39,20 +39,26 @@ def updateRestShapeInterface(window):
 		if not bret & QMessageBox.Ok:
 			return
 
-	updateRestShape(mesh, sel)
+	updateRestShape(mesh, sel, window=window)
 
-def updateRestShape(mesh, newRest):
+def updateRestShape(mesh, newRest, window=None):
 	allShapes = cmds.listRelatives(mesh, children=1, shapes=1) or []
 	noInter = cmds.listRelatives(mesh, children=1, shapes=1, noIntermediate=1) or []
-	inter = list(set(allShapes) - set(noInter))
+	hist = cmds.listHistory(mesh)
+	inter = (set(allShapes) - set(noInter)) & set(hist)
 	if not inter:
+		if window is not None:
+			QMessageBox.warning(window, "No Intermediates", "No intermediate meshes found")
 		return
+	inter = list(inter)
 
 	if len(inter) == 1:
 		orig = inter[0]
 	else:
-		origs = [i for i in inter if i.endswith('Orig')]
+		origs = [i for i in inter if 'Orig' in i]
 		if len(origs) != 1:
+			if window is not None:
+				QMessageBox.warning(window, "Too Many Intermediates", "Too Many intermediate meshes found: {0}".format(origs))
 			return
 		orig = origs[0]
 

--- a/scripts/SimplexUI/tools/mayaTools.py
+++ b/scripts/SimplexUI/tools/mayaTools.py
@@ -19,7 +19,7 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 #pylint: disable=no-self-use, fixme, missing-docstring
 import mayaPlugins as plugins
 import genericPlugins
-from SimplexUI.Qt.QtWidgets import QMenu
+from ..Qt.QtWidgets import QMenu
 
 # Registration class
 def loadPlugins():

--- a/scripts/SimplexUI/tools/xsiTools.py
+++ b/scripts/SimplexUI/tools/xsiTools.py
@@ -19,7 +19,7 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 #pylint: disable=no-self-use, fixme, missing-docstring
 import xsiPlugins as plugins
 import genericPlugins
-from SimplexUI.Qt.QtWidgets import QMenu
+from ..Qt.QtWidgets import QMenu
 
 # Registration class
 def loadPlugins():

--- a/scripts/SimplexUI/traversalDialog.py
+++ b/scripts/SimplexUI/traversalDialog.py
@@ -25,17 +25,17 @@ import re
 
 # This module imports QT from PyQt4, PySide or PySide2
 # Depending on what's available
-from SimplexUI.Qt import QtCompat
-from SimplexUI.Qt.QtGui import QStandardItemModel
-from SimplexUI.Qt.QtWidgets import QMessageBox, QInputDialog, QApplication, QDialog, QProgressDialog
+from .Qt import QtCompat
+from .Qt.QtGui import QStandardItemModel
+from .Qt.QtWidgets import QMessageBox, QInputDialog, QApplication, QDialog, QProgressDialog
 
-from SimplexUI.utils import getUiFile, makeUnique
-from SimplexUI.interfaceItems import (Slider, Combo, Traversal, Group, Simplex)
-from SimplexUI.interfaceModel import (SliderModel, TraversalModel, TraversalFilterModel,
+from .utils import getUiFile, makeUnique
+from .interfaceItems import (Slider, Combo, Traversal, Group, Simplex)
+from .interfaceModel import (SliderModel, TraversalModel, TraversalFilterModel,
 							coerceIndexToRoots, coerceIndexToType, SimplexModel)
 
-from SimplexUI.interface import DCC
-from SimplexUI.interfaceModelTrees import TraversalTree
+from .interface import DCC
+from .interfaceModelTrees import TraversalTree
 
 try:
 	# This module is unique to Blur Studio

--- a/scripts/SimplexUI/ui/comboCheckDialog.ui
+++ b/scripts/SimplexUI/ui/comboCheckDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>686</width>
-    <height>702</height>
+    <width>833</width>
+    <height>362</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -213,151 +213,206 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
 
 </string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string>Combo Size Limits</string>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <widget class="QWidget" name="uiHeaderWID" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <widget class="QGroupBox" name="uiLimitGRP">
+        <property name="title">
+         <string>Combo Size Limits</string>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Min</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="uiMinLimitSPIN">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="minimum">
+            <number>2</number>
+           </property>
+           <property name="maximum">
+            <number>7</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="Line" name="line">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>Max</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="uiMaxLimitSPIN">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="minimum">
+            <number>2</number>
+           </property>
+           <property name="maximum">
+            <number>7</number>
+           </property>
+           <property name="value">
+            <number>5</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>511</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout">
         <item>
-         <widget class="QLabel" name="label_3">
+         <widget class="QCheckBox" name="uiAutoUpdateCHK">
+          <property name="toolTip">
+           <string>Auto update sliders from UI selection</string>
+          </property>
           <property name="text">
-           <string>Min</string>
+           <string>Auto Update</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QSpinBox" name="uiMinLimitSPIN">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
+         <widget class="QPushButton" name="uiManualUpdateBTN">
+          <property name="enabled">
+           <bool>false</bool>
           </property>
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="minimum">
-           <number>2</number>
-          </property>
-          <property name="maximum">
-           <number>7</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="Line" name="line">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="label_4">
           <property name="text">
-           <string>Max</string>
+           <string>Manual Update</string>
           </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="uiMaxLimitSPIN">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="minimum">
-           <number>2</number>
-          </property>
-          <property name="maximum">
-           <number>7</number>
-          </property>
-          <property name="value">
-           <number>5</number>
+          <property name="bgColor" stdset="0">
+           <string>orange</string>
           </property>
          </widget>
         </item>
        </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="uiWarningLBL">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>1</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QCheckBox" name="uiAutoUpdateCHK">
-         <property name="text">
-          <string>Auto Update</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="uiManualUpdateBTN">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Manual Update</string>
-         </property>
-         <property name="bgColor" stdset="0">
-          <string>orange</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QLabel" name="label_2">
+    <widget class="QSplitter" name="splitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QTreeWidget" name="uiEditTREE">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>1</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::ExtendedSelection</enum>
+      </property>
+      <property name="rootIsDecorated">
+       <bool>false</bool>
+      </property>
+      <property name="itemsExpandable">
+       <bool>false</bool>
+      </property>
+      <column>
        <property name="text">
-        <string>Combos</string>
+        <string>Slider</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QListWidget" name="uiComboCheckLIST">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>2</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+      </column>
+      <column>
+       <property name="text">
+        <string>-1</string>
        </property>
-       <property name="selectionMode">
-        <enum>QAbstractItemView::ExtendedSelection</enum>
+      </column>
+      <column>
+       <property name="text">
+        <string>+1</string>
        </property>
-      </widget>
-     </item>
-    </layout>
+      </column>
+      <column>
+       <property name="text">
+        <string>Val</string>
+       </property>
+      </column>
+     </widget>
+     <widget class="QListWidget" name="uiComboCheckLIST">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>2</horstretch>
+        <verstretch>1</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::ExtendedSelection</enum>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="uiWarningLBL">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/scripts/SimplexUI/ui/simplexInterfaceDialog.ui
+++ b/scripts/SimplexUI/ui/simplexInterfaceDialog.ui
@@ -101,13 +101,23 @@ QHeaderView::section {
      border-radius: 4px;
  }
 
- QMenuBar::item:selected { /* when selected using mouse or keyboard */
+
+ QMenuBar::item:selected {
      background: rgb(168, 168, 168);
  }
 
  QMenuBar::item:pressed {
      background: rgb(136, 136, 136);
  }
+
+ QMenu::item:selected {
+     background: rgb(168, 168, 168);
+ }
+
+ QMenu::item:pressed {
+     background: rgb(136, 136, 136);
+ }
+
 
 QWidget:pressed {
 	background-color: rgb(50, 50, 50);
@@ -600,6 +610,16 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
             </spacer>
            </item>
            <item>
+            <widget class="QCheckBox" name="uiAutoSetSlidersCHK">
+             <property name="toolTip">
+              <string>Automatically set the currently selected sliders to 1.0</string>
+             </property>
+             <property name="text">
+              <string>Auto Set</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QPushButton" name="uiSelectCtrlBTN">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -821,12 +841,107 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
             <number>2</number>
            </property>
            <item>
+            <widget class="QPushButton" name="uiNewComboActiveBTN">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string>Make a combo out of any non-zero sliders</string>
+             </property>
+             <property name="text">
+              <string>Combo Active</string>
+             </property>
+             <property name="bgColor" stdset="0">
+              <string>lightBlue</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="uiNewComboSelectBTN">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string>Make a combo out of the selected sliders</string>
+             </property>
+             <property name="text">
+              <string>Combo Selected</string>
+             </property>
+             <property name="bgColor" stdset="0">
+              <string>lightBlue</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="uiNewComboGroupBTN">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string>Make a new group from the selected combos</string>
+             </property>
+             <property name="text">
+              <string>Group</string>
+             </property>
+             <property name="bgColor" stdset="0">
+              <string>lightBlue</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="uiNewComboShapeBTN">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string>Add a shape to the selected combos' progressions</string>
+             </property>
+             <property name="text">
+              <string>Shape</string>
+             </property>
+             <property name="bgColor" stdset="0">
+              <string>lightBlue</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="uiDeleteComboBTN">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="toolTip">
+              <string>Delete the selected items (Group, Combo, or Shape)</string>
+             </property>
+             <property name="text">
+              <string>Delete</string>
+             </property>
+             <property name="bgColor" stdset="0">
+              <string>lightBlue</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QGroupBox" name="uiShowDependentGRP">
              <property name="toolTip">
               <string>Enable auto-filtering based on the slider selection</string>
              </property>
              <property name="title">
-              <string>Filter</string>
+              <string>Slider Filter</string>
              </property>
              <property name="flat">
               <bool>true</bool>
@@ -928,101 +1043,6 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
             </widget>
            </item>
            <item>
-            <widget class="QPushButton" name="uiNewComboActiveBTN">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>Make a combo out of any non-zero sliders</string>
-             </property>
-             <property name="text">
-              <string>Combo Active</string>
-             </property>
-             <property name="bgColor" stdset="0">
-              <string>lightBlue</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="uiNewComboSelectBTN">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>Make a combo out of the selected sliders</string>
-             </property>
-             <property name="text">
-              <string>Combo Selected</string>
-             </property>
-             <property name="bgColor" stdset="0">
-              <string>lightBlue</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="uiNewComboGroupBTN">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>Make a new group from the selected combos</string>
-             </property>
-             <property name="text">
-              <string>Group</string>
-             </property>
-             <property name="bgColor" stdset="0">
-              <string>lightBlue</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="uiNewComboShapeBTN">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>Add a shape to the selected combos' progressions</string>
-             </property>
-             <property name="text">
-              <string>Shape</string>
-             </property>
-             <property name="bgColor" stdset="0">
-              <string>lightBlue</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QPushButton" name="uiDeleteComboBTN">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>Delete the selected items (Group, Combo, or Shape)</string>
-             </property>
-             <property name="text">
-              <string>Delete</string>
-             </property>
-             <property name="bgColor" stdset="0">
-              <string>lightBlue</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <spacer name="verticalSpacer">
              <property name="orientation">
               <enum>Qt::Vertical</enum>
@@ -1034,6 +1054,16 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
               </size>
              </property>
             </spacer>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="uiAutoSetCombosCHK">
+             <property name="toolTip">
+              <string>Automatically set the sliders for the currently selected combos</string>
+             </property>
+             <property name="text">
+              <string>Auto Set</string>
+             </property>
+            </widget>
            </item>
            <item>
             <widget class="QPushButton" name="uiSelectSlidersBTN">

--- a/scripts/SimplexUI/ui/simplexInterfaceDialog.ui
+++ b/scripts/SimplexUI/ui/simplexInterfaceDialog.ui
@@ -28,10 +28,14 @@ QWidget{
 	font: 8pt &quot;MS Shell Dlg 2&quot;;
 }
 
+QWidget:disabled{
+	color: rgb(90, 90, 90);
+}
+
 QGroupBox{
     border: 2px solid rgb(96, 96, 96);
     border-radius: 5px;
-    margin-top: 2ex; /* leave space at the top for the title */
+   margin-top: 2ex;  /* leave space at the top for the title */
 	padding: 4px 0px;
 	/*padding-top: 3px;
 	padding-bottom: 3px;*/
@@ -64,8 +68,6 @@ QLineEdit{
 	background-color: rgb(130, 130, 130);
 	border: 2px solid rgb(56, 56, 56);
 }
-
-
 
 
 
@@ -313,7 +315,7 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
             </size>
            </property>
            <property name="toolTip">
-            <string>Load the first selected object from the scene</string>
+            <string>Unload the current object</string>
            </property>
            <property name="text">
             <string>x</string>
@@ -701,7 +703,7 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
                </size>
               </property>
               <property name="toolTip">
-               <string>Clear the filter</string>
+               <string>Clear the slider name filter</string>
               </property>
               <property name="text">
                <string>x</string>
@@ -714,7 +716,7 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
             <item>
              <widget class="QPushButton" name="uiSliderExitIsolateBTN">
               <property name="toolTip">
-               <string>Exit isolation mode</string>
+               <string>Exit isolation mode for sliders</string>
               </property>
               <property name="text">
                <string>Exit Isolate</string>
@@ -776,7 +778,7 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
                </size>
               </property>
               <property name="toolTip">
-               <string>Clear the filter</string>
+               <string>Clear the combo name filter</string>
               </property>
               <property name="text">
                <string>x</string>
@@ -789,7 +791,7 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
             <item>
              <widget class="QPushButton" name="uiComboExitIsolateBTN">
               <property name="toolTip">
-               <string>Exit isolation mode</string>
+               <string>Exit isolation mode for combos</string>
               </property>
               <property name="text">
                <string>Exit Isolate</string>
@@ -819,55 +821,111 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
             <number>2</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_7">
-             <property name="text">
-              <string>Show Dependent</string>
+            <widget class="QGroupBox" name="uiShowDependentGRP">
+             <property name="toolTip">
+              <string>Enable auto-filtering based on the slider selection</string>
              </property>
+             <property name="title">
+              <string>Filter</string>
+             </property>
+             <property name="flat">
+              <bool>true</bool>
+             </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_3">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>1</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="QWidget" name="uiShowDependentWID" native="true">
+                <layout class="QVBoxLayout" name="verticalLayout_4">
+                 <property name="spacing">
+                  <number>3</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>6</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>3</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>6</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>3</number>
+                 </property>
+                 <item>
+                  <widget class="QRadioButton" name="uiComboDependAnyRDO">
+                   <property name="toolTip">
+                    <string>Show combos that depend on *any* of the selected sliders</string>
+                   </property>
+                   <property name="text">
+                    <string>Contains Any</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="uiComboDependOnlyRDO">
+                   <property name="toolTip">
+                    <string>Show combos that are made up of *only* the selected sliders</string>
+                   </property>
+                   <property name="text">
+                    <string>Contains Only</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QRadioButton" name="uiComboDependAllRDO">
+                   <property name="toolTip">
+                    <string>Show combos that contain *All* of the selected sliders (possibly more)</string>
+                   </property>
+                   <property name="text">
+                    <string>Contains All</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="Line" name="line">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QCheckBox" name="uiComboDependLockCHK">
+                   <property name="toolTip">
+                    <string>Lock the &quot;Show&quot; filter inputs so you can change the slider selection without updating the display</string>
+                   </property>
+                   <property name="text">
+                    <string>Lock Filter</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
             </widget>
-           </item>
-           <item>
-            <layout class="QGridLayout" name="gridLayout">
-             <item row="0" column="0">
-              <widget class="QCheckBox" name="uiComboDependAnyCHK">
-               <property name="toolTip">
-                <string>Show combos that depend on *any* of the selected sliders</string>
-               </property>
-               <property name="text">
-                <string> Any</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QCheckBox" name="uiComboDependAllCHK">
-               <property name="toolTip">
-                <string>Show combos that depend on *all* of the selected sliders</string>
-               </property>
-               <property name="text">
-                <string>Exact</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QCheckBox" name="uiComboDependOnlyCHK">
-               <property name="toolTip">
-                <string>Show combos that are made up of *only* the selected sliders</string>
-               </property>
-               <property name="text">
-                <string>Only</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="QCheckBox" name="uiComboDependLockCHK">
-               <property name="toolTip">
-                <string>Show combos that are made up of *only* the selected sliders</string>
-               </property>
-               <property name="text">
-                <string>Lock</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
            </item>
            <item>
             <widget class="QPushButton" name="uiNewComboActiveBTN">
@@ -954,7 +1012,7 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
               </sizepolicy>
              </property>
              <property name="toolTip">
-              <string>Delete the selected combos</string>
+              <string>Delete the selected items (Group, Combo, or Shape)</string>
              </property>
              <property name="text">
               <string>Delete</string>
@@ -1254,54 +1312,5 @@ QWidget[bgColor=&quot;darkYellow&quot;]:disabled {
   </action>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>uiComboDependLockCHK</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>uiComboDependAllCHK</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>949</x>
-     <y>138</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>943</x>
-     <y>114</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>uiComboDependLockCHK</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>uiComboDependAnyCHK</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>932</x>
-     <y>135</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>894</x>
-     <y>109</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>uiComboDependLockCHK</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>uiComboDependOnlyCHK</receiver>
-   <slot>setDisabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>959</x>
-     <y>138</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>898</x>
-     <y>144</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/scripts/SimplexUI/utils.py
+++ b/scripts/SimplexUI/utils.py
@@ -154,9 +154,10 @@ class singleShot(QObject):
 		self._function(inst, args)
 
 def makeUnique(seq):
-    seen = set()
-    seen_add = seen.add
-    return [x for x in seq if not (x in seen or seen_add(x))]
+	''' Make a sequence unique, keeping the first time each item is seen '''
+	seen = set()
+	seen_add = seen.add
+	return [x for x in seq if not (x in seen or seen_add(x))]
 
 class nested(object):
 	"""Combine multiple context managers into a single nested context manager.
@@ -190,5 +191,5 @@ class nested(object):
 			mgr.__exit__(excType, exc, trace)
 
 def naturalSortKey(s, _nsre=re.compile('([0-9]+)')):
-    return [int(text) if text.isdigit() else text.lower() for text in _nsre.split(s)]    
+	return [int(text) if text.isdigit() else text.lower() for text in _nsre.split(s)]	 
 

--- a/scripts/SimplexUI/utils.py
+++ b/scripts/SimplexUI/utils.py
@@ -19,7 +19,7 @@ along with Simplex.  If not, see <http://www.gnu.org/licenses/>.
 
 """Utility functions."""
 import os, sys, re
-from SimplexUI.Qt.QtCore import QObject, QTimer
+from .Qt.QtCore import QObject, QTimer
 
 def toPyObject(thing):
 	''' Because we could still be in the sip api 1.0 '''
@@ -156,7 +156,7 @@ class singleShot(QObject):
 def makeUnique(seq):
 	''' Make a sequence unique, keeping the first time each item is seen '''
 	seen = set()
-	seen_add = seen.add
+	seen_add = seen.add #only resolve the method lookup once
 	return [x for x in seq if not (x in seen or seen_add(x))]
 
 class nested(object):
@@ -191,5 +191,5 @@ class nested(object):
 			mgr.__exit__(excType, exc, trace)
 
 def naturalSortKey(s, _nsre=re.compile('([0-9]+)')):
-	return [int(text) if text.isdigit() else text.lower() for text in _nsre.split(s)]	 
+	return [int(text) if text.isdigit() else text.lower() for text in _nsre.split(s)]
 

--- a/scripts/SimplexUI/xsiInterface.py
+++ b/scripts/SimplexUI/xsiInterface.py
@@ -23,9 +23,9 @@ from contextlib import contextmanager
 from functools import wraps
 from itertools import repeat
 import dcc.xsi as dcc
-from SimplexUI.Qt import QtCore
-from SimplexUI.Qt.QtCore import Signal
-from SimplexUI.Qt.QtWidgets import QApplication, QSplashScreen, QDialog, QMainWindow
+from .Qt import QtCore
+from .Qt.QtCore import Signal
+from .Qt.QtWidgets import QApplication, QSplashScreen, QDialog, QMainWindow
 
 import alembic
 from alembic.AbcGeom import OPolyMeshSchemaSample
@@ -33,8 +33,8 @@ from imath import V3f, V3fArray, IntArray
 from imathnumpy import arrayToNumpy #pylint:disable=no-name-in-module
 import numpy as np
 
-from SimplexUI.commands.buildIceXML import buildIceXML, buildSliderIceXML, buildLoaderXML
-from SimplexUI.commands.alembicCommon import mkUvSample
+from .commands.buildIceXML import buildIceXML, buildSliderIceXML, buildLoaderXML
+from .commands.alembicCommon import mkUvSample
 
 # UNDO STACK INTEGRATION
 @contextmanager
@@ -620,6 +620,9 @@ class DCC(object):
 			abcFaceCounts[i] = faceCounts[i]
 
 		return abcFaceIndices, abcFaceCounts, uvSample
+
+	def loadMeshTopology(self):
+		self._faces, self._counts, self._uvs = self._exportAbcFaces(self.mesh)
 
 	def exportAbc(self, dccMesh, abcMesh, js, world=False, pBar=None):
 		# dccMesh doesn't work in XSI, so just ignore it


### PR DESCRIPTION
Yet another massive PR that probably should have been 4 or 5. But since I'm the only guy messing with this, it shouldn't be an issue.

This branch *started* with the idea that renaming should cascade: Rename a slider that a combo depends on? The combo should get the update. Also (the harder part) vice versa. The skeleton of that system is in place, but not in use.

However, this ended up as a delegation of choices.  The simplex items themselves now handle how they organize in the separate trees, and we don't have massive if/elif trees in the Models.

Then I fixed a lot of bugs, made combo creation always go through the ComboChecker, unified alembic backend handling, and made all the imports relative.
I also fixed UnSubdivide, and added a uv-space transfer (which may not work outside of Blur for a while).