### PR TITLE
Because I'm using Qt.py, it's up to the user to choose to install PyS…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 
 dependencies = [
     "six",
-    "PySide2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Because I'm using Qt.py, it's up to the user to choose to install PySide2 or PyQt5
So I need to remove that as a dependency from the pip packages.