### PR TITLE
Fix install path to avoid nested modules folder 

### DIFF
--- a/simplex_maya_installer.py
+++ b/simplex_maya_installer.py
@@ -211,7 +211,22 @@ def onMayaDroppedPythonFile(obj):
             raise RuntimeError("Download of simplex zip failed")
 
         with zipfile.ZipFile(simplex_zip, "r") as zip_ref:
-            zip_ref.extractall(mod_folder)
+            for member in zip_ref.namelist():
+                # Skip anything not in the top-level 'modules/' folder
+                if not member.startswith("modules/") or member.endswith("/"):
+                    continue
+
+                # Strip the 'modules/' prefix
+                relative_path = member[len("modules/"):]
+                target = mod_folder / relative_path
+
+                # Ensure target folder exists
+                target.parent.mkdir(parents=True, exist_ok=True)
+
+                # Extract the file
+                with zip_ref.open(member) as source, open(target, "wb") as dest:
+                    dest.write(source.read())
+                    
         os.remove(simplex_zip)
 
         mayapy = get_mayapy_path()


### PR DESCRIPTION
This updates the unzip logic in the installer to strip the leading `"modules/"` 
prefix from extracted files, ensuring they're placed directly into 
`Documents/maya/modules/` as expected.

In some cases — possibly only when a 'modules/' folder already exists — the 
installer was creating a nested path like `modules/modules/simplex/`, which Maya 
does not scan by default.

A short video demonstrating the original  issue:
https://www.youtube.com/watch?v=CIuHuzalAiE

---

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) document
- [x] I kept the change self-contained and avoided new dependencies
- [ ] I formatted my changes with [black](https://github.com/psf/black)
- [ ] I linted my changes with [flake8](https://gitlab.com/pycqa/flake8)
- [x] I have added documentation where necessary
- [x ] Existing behavior continues to work as expected
- [x] I manually tested the fix in Maya

## Types of Changes

- [x] Bugfix (installation path fix)
- [ ] New Feature
- [ ] Documentation Update

## Proposed Changes

This change adjusts the zip extraction behavior so that Simplex installs cleanly 
into the expected `Documents/maya/modules` location without nesting module folders. I tested it in Maya 2024 in a scenario where no modules folder was present and where one was present.
